### PR TITLE
Clarified minDate/maxDate requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Pikaday has many useful options:
 * `defaultDate` the initial date to view when first opened
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)
-* `minDate` the minimum/earliest date that can be selected
-* `maxDate` the maximum/latest date that can be selected
+* `minDate` the minimum/earliest date that can be selected (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)
+* `maxDate` the maximum/latest date that can be selected (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)
 * `yearRange` number of years either side (e.g. `10`) or array of upper/lower range (e.g. `[1900,2012]`)
 * `isRTL` reverse the calendar for right-to-left languages
 * `i18n` language defaults for month and weekday names (see internationalization below)


### PR DESCRIPTION
I found the documentation for minDate/maxDate confusing, as I was trying to simply pass in a date string: `{minDate: "2011-11-11"}` and couldn't figure out why things weren't working.

Added a note about requiring a native `Date` to prevent future confusion.
