### PR TITLE
Manual entry is incorrectly parsed.

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -335,8 +335,13 @@
 
         self._onInputChange = function(e)
         {
-            var date = new Date(Date.parse(opts.field.value));
-            self.setDate(isDate(date) ? date : null);
+            if (hasMoment) {
+                self.setDate(window.moment(opts.field.value, opts.format).toDate());
+            }
+            else {
+                var date = new Date(Date.parse(opts.field.value));
+                self.setDate(isDate(date) ? date : null);
+            }
             if (!self._v) {
                 self.show();
             }


### PR DESCRIPTION
When manually changing the date in the text input field, Pikaday is not taking the format option into account.

Eg. when using options like:

``` javascript
  { format: 'D-M-YYYY' }
```

The day and month will be switched when entering the following date: 01-12-2012 (December 1st, 2012). (Because new Date() will parse it as January 12th 2012)
