### PR TITLE
Handling empty string values + 'change' trigger

### DIFF
--- a/plugins/pikaday.jquery.js
+++ b/plugins/pikaday.jquery.js
@@ -372,20 +372,15 @@
 
         self._onInputChange = function(e)
         {
-            if (self.isChangeTriggered !== true)
-            {
-                var date;
-                if (hasMoment) {
-                    date = window.moment(opts.field.value, opts.format);
-                }
-                else {
-                    date = new Date(Date.parse(opts.field.value));
-                }
-                self.setDate(date ? date.toDate() : null);
-
-                if (!self._v) {
-                    self.show();
-                }
+            if (hasMoment) {
+                self.setDate(window.moment(opts.field.value, opts.format).toDate());
+            }
+            else {
+                var date = new Date(Date.parse(opts.field.value));
+                self.setDate(isDate(date) ? date : null);
+            }
+            if (!self._v) {
+                self.show();
             }
         };
 
@@ -433,26 +428,6 @@
                 self.hide();
             }
         };
-
-        /**
-         * Triggers the change event on the source element
-         */
-        self._triggerChange = function () {
-
-            self.isChangeTriggered = true;
-
-            if ('fireEvent' in this._o.field)
-                self._o.field.fireEvent('onchange');
-            else
-            {
-                var evt = document.createEvent('HTMLEvents');
-                evt.initEvent('change', true, true);
-                self._o.field.dispatchEvent(evt);
-            }
-
-            self.isChangeTriggered = false;
-        };
-
 
         self.el = document.createElement('div');
         self.el.className = 'pika-single' + (opts.isRTL ? ' is-rtl' : '');
@@ -615,10 +590,7 @@
             this.gotoDate(this._d);
 
             if (this._o.field) {
-                var value = this.toString();
-                this._o.field.value = value;
-                this._o.field.setAttribute('value', value);
-                this._triggerChange();
+                this._o.field.value = this.toString();
             }
             if (typeof this._o.onSelect === 'function') {
                 this._o.onSelect.call(this, this.getDate());


### PR DESCRIPTION
This PR correct
- "Uncaught TypeError: Cannot call method 'toDate' of null" error in case of empty values in input holder associated to calendar
- Trigger 'change' event on date modification; Now you can subscribe (with binding/validation libraries) to source field value
