### PR TITLE
Prevent onSelect from triggering if date is set on initialisation

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -420,7 +420,7 @@
 
         if (isDate(defDate)) {
             if (opts.setDefaultDate) {
-                self.setDate(defDate);
+                self.setDate(defDate, true);
             } else {
                 self.gotoDate(defDate);
             }
@@ -526,7 +526,7 @@
         /**
          * set the current selection
          */
-        setDate: function(date)
+        setDate: function(date, preventOnSelect)
         {
             if (!date) {
                 this._d = null;
@@ -555,7 +555,7 @@
             if (this._o.field) {
                 this._o.field.value = this.toString();
             }
-            if (typeof this._o.onSelect === 'function') {
+            if (!preventOnSelect && typeof this._o.onSelect === 'function') {
                 this._o.onSelect.call(this, this.getDate());
             }
         },


### PR DESCRIPTION
Currently if `onSelect` and `setDefaultDate` (and, obviously, `defaultDate`) are set, then the `onSelect` callback gets triggered immediately when the picker is created. This is probably not what is intended (as in my use-case, where the `onSelect` listener will close the picker immediately when opened).
