### PR TITLE
Handling empty string values

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -352,16 +352,18 @@
 
         self._onInputChange = function(e)
         {
+            var date;
+
             if (e.firedBy === self) {
                 return;
             }
             if (hasMoment) {
-                self.setDate(window.moment(opts.field.value, opts.format).toDate());
+                date = window.moment(opts.field.value, opts.format);
             }
             else {
-                var date = new Date(Date.parse(opts.field.value));
-                self.setDate(isDate(date) ? date : null);
+                date = new Date(Date.parse(opts.field.value));
             }
+            self.setDate(date ? date.toDate() : null);
             if (!self._v) {
                 self.show();
             }


### PR DESCRIPTION
This PR correct "Uncaught TypeError: Cannot call method 'toDate' of null" error in case of empty values in input holder associated to calendar
