### PR TITLE
Add Pikaday gem to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If you're using **jQuery** make sure to pass only the first element:
 var picker = new Pikaday({ field: $('#datepicker')[0] });
 ```
 
+If you're using **Ruby on Rails**, make sure to check out the [Pikaday gem](https://rubygems.org/gems/pikaday-gem).
+
 If the Pikaday instance is not bound to a field you can append the element anywhere:
 
 ```javascript


### PR DESCRIPTION
Thank you so much for creating the pikaday datepicker.
Since we're working on a Ruby on Rails project we've created an open-source gem which bundles it.

You can find it at https://rubygems.org/gems/pikaday-gem
Source code is at https://github.com/ets-berkeley-edu/pikaday-gem
And readme at https://github.com/ets-berkeley-edu/pikaday-gem#readme

It relies on the fact that you're tagging new versions. So far there is only `1.0.0` but we're already looking forward to the next one.

We'll also version our gem in the following way.
The first 3 (x.x.x) will be the same as your version, while the last digit (_._._.x) will be gem updates.

Hope you'll like it.
