### PR TITLE
Use format provided in options for toString

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -555,7 +555,8 @@
          */
         toString: function(format)
         {
-            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
+            format = format || this._o.format
+            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format) : format ? this._d.toString(format) : this._d.toDateString();
         },
 
         /**


### PR DESCRIPTION
I didn't want to take a dependency on moment, but wanted the displayed to the user to be the format I provided.

This will break existing behavior of toString for people not using moment.  If you feel it is important to preserve that existing behavior let me know and I'll change the code.

Let me know if you have any other feedback or thoughts on this change.
