### PR TITLE
Trigger `onInputNoDate` with user's input when it cannot register as a selection

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -389,8 +389,12 @@
             }
             else {
                 date = new Date(Date.parse(opts.field.value));
+                date = isDate(date) ? date : null;
             }
-            self.setDate(isDate(date) ? date : null);
+            if (date === null && typeof self._o.onInputNoDate === 'function') {
+                self._o.onInputNoDate.call(self, opts.field.value);
+            }
+            self.setDate(date);
             if (!self._v) {
                 self.show();
             }


### PR DESCRIPTION
Hi,

I'm using Pikaday in a backbone app with [model validations](https://github.com/thedersen/backbone.validation). While I'm able to bind the datepicker value to the model easily through `onSelect`, `onSelect` quite rightfully isn't called when the user enters something into the input field that cannot be registered as a selection.

So.... with the current absence of an equivalent handler option exposed through the API, I implemented `onInputNoDate`. Now, for example, I can initialize a Pikaday instance for users to enter a payment date and know that validation will be carried out regardless, and thus the necessary messages will always be displayed.

  new Pikaday({
    field: view.$('#payment-date')[0],
    onSelect: function (date) {
      view.model.set('date', date.getTime());
    },
    onInputNoDate: function (input) {
      view.model.set('date', input);
    }
  });

Then in the model class...
  validations: {
    date: {
      required: true,
      pattern:  'date'
    }
  }

I really like Pikaday and thought this could also be useful for others. Hope you'll consider it.

Thanks for the great tool!
Sean
