### PR TITLE
Match case of package name for bower's search

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Pikaday",
+  "name": "pikaday",
   "version": "1.2.0",
   "main": [
     "./pikaday.js",


### PR DESCRIPTION
With the current capitalized name, [bower](http://bower.io) cannot find it when searching.

``` bash
$ bower search Pikaday
No results
```

When you search for `pikaday`, you find what you expect:

``` bash
$ bower search pikaday
Search results:

    pikaday git://github.com/dbushell/Pikaday
```

But if you save `Pikaday` to your bower.json (`bower install pikaday --save`), it adds "Pikaday" to your dependencies: 

``` json
"Pikaday": "~1.1.0"
```

This causes errors later when installing:

``` bash
$ bower install
...
bower error Pikaday not found
...
There were errors, here's a summary of them:
- Pikaday not found
```

Changing the package name to `pikaday` should fix this workflow issue
