### PR TITLE
Added 'moment' option so that moment.js can be injected

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -335,6 +335,11 @@
         var self = this,
             opts = self.config(options);
 
+        if (options.moment !== undefined) {
+            moment = options.moment;
+            hasMoment = true;
+        }
+        
         self._onMouseDown = function(e)
         {
             if (!self._v) {


### PR DESCRIPTION
Pikaday assumes moment.js will be a global variable. Sometimes dependencies are wrapped inside of a dependency resolution mechanism, and so normal global variables for libraries do not exist. With this update one can pass in moment.js as an option:

var moment = dependencyMechanism.get('moment');
var pk = new Pikaday({
  moment: moment
  ...
});
