### PR TITLE
Use proper UMD-wrapper

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -4,7 +4,7 @@
  * Copyright © 2013 David Bushell | BSD & MIT license | https://github.com/dbushell/Pikaday
  */
 
-(function (root, define, factory)
+(function (root, factory)
 {
     'use strict';
 
@@ -21,7 +21,7 @@
         // Browser global
         root.Pikaday = factory(root.moment);
     }
-}(window, window.define, function (moment)
+}(this, function (moment)
 {
     'use strict';
 


### PR DESCRIPTION
Updated the UMD to use the proper UMD-Wrapper.
Passing window as root, doesn't add flexibility. The same with window.define.

Passing in this as root, enables the root element to change - default browser behaviour is window.

See more for inspiration:
https://github.com/umdjs/umd/blob/master/amdWeb.js
