### PR TITLE
Add Fully-Fledged Events to the Date Picker

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -642,8 +642,8 @@
             if (!preventOnSelect) {
                 this.trigger('select', this.getDate());
                 
-                if (typeof this.onSelect == 'function') {
-                    this.onSelect(this.getDate());
+                if (typeof this._o.onSelect == 'function') {
+                    this._o.onSelect.call(this, this.getDate());
                 }
             }
         },
@@ -764,8 +764,8 @@
             sto(function() {
                 self.trigger('draw');
                 
-                if (typeof self.onDraw == 'function') {
-                    self.onDraw();
+                if (typeof self._o.onDraw == 'function') {
+                    self._o.onDraw.call(self);
                 }
             }, 0);
         },
@@ -861,8 +861,8 @@
                 
                 this.trigger('open');
                 
-                if (typeof this.onOpen == 'function') {
-                    this.onOpen();
+                if (typeof this._o.onOpen == 'function') {
+                    this._o.onOpen.call(this);
                 }
             }
         },
@@ -880,8 +880,8 @@
                 if (v !== undefined) {
                     this.trigger('close');
                     
-                    if (typeof this.onClose == 'function') {
-                        this.onClose();
+                    if (typeof this._o.onClose == 'function') {
+                        this._o.onClose.call(this);
                     }
                 }
             }


### PR DESCRIPTION
Hello,

It would be nice if this were able to bind multiple callbacks per event. I added an events subsystem (identical in API to that in use by Backbone, except for the addition of `triggerMethod` from Backbone.Marionette) and modified it slightly to call the event callbacks from the configuration object. This change won't break the API for existing users; it'll just add the ability to use `on`, `off`, `once`, etc. to bind multiple callbacks to each event.

I had written this events subsystem for another project: https://github.com/mcordingley/Appliance The events are fully unit-tested in that project.
