### PR TITLE
Use a px text-indent on .pika-prev/next to prevent Firefox bug

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -66,13 +66,14 @@
     padding: 0;
     width: 20px;
     height: 30px;
+    /* hide text using text-indent trick, using width value (it's enough) */
+    text-indent: 20px;
+    white-space: nowrap;
+    overflow: hidden;
     background-color: transparent;
     background-position: center center;
     background-repeat: no-repeat;
     background-size: 75% 75%;
-    white-space: nowrap;
-    text-indent: 100%;
-    overflow: hidden;
     opacity: .5;
     *position: absolute;
     *top: 0;


### PR DESCRIPTION
This bug https://bugzilla.mozilla.org/show_bug.cgi?id=908706
make the first letter of this buttons visible.

Before

![screen shot 2014-01-24 at 17 13 16](https://f.cloud.github.com/assets/157534/1996429/0ff5915e-8514-11e3-8995-56717a755b38.png)

After

![screen shot 2014-01-24 at 17 25 20](https://f.cloud.github.com/assets/157534/1996446/3b8a7ec4-8514-11e3-9142-601405e8080a.png)

Approved on Gecko & Webkit browsers.
