### PR TITLE
Allow multiple input formats, add onClear callback for better Ember/Knockout/etc integration and allow other date libraries instead of Moment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Hide the picker making it invisible.
 
 Hide the picker and remove all event listeners — no going back!
 
-### Internationalization
+## Internationalization
 
 The default `i18n` configuration format looks like this:
 
@@ -260,9 +260,13 @@ i18n: {
 
 You must provide 12 months and 7 weekdays (with abbreviations). Always specify weekdays in this order with Sunday first. You can change the `firstDay` option to reorder if necessary (0: Sunday, 1: Monday, etc). You can also set `isRTL` to `true` for languages that are read right-to-left.
 
-### Custom date parser and formatter functions
+## Custom Date Parsing and Formatting
 
-Although [Moment.js][moment] is recommended, alternate Javascript Date libraries such as [Sugar][] can be used by overriding `picker.parseDate()` and `picker.toString()` with custom date parser and formatter functions. See the [Sugar example][] for a full example.
+Although [Moment.js][moment] is recommended, alternate Javascript Date libraries such as [Sugar][] can be used by overriding `parseDate` and `toString` on `Pikaday.prototype` with custom date parser and formatter functions. See the [Sugar example][] for a full example.
+
+## MVC Framework Integration
+
+Pikaday can be easily integrated with most Javascript MVC Frameworks such as [Ember][] and [Knockout][]. See the [Ember example][] and [Knockout example][] for example integrations.
 
 ## Extensions
 
@@ -295,29 +299,33 @@ Thanks to [@shoogledesigns][shoogledesigns] for the name.
 
 Copyright © 2014 David Bushell | BSD & MIT license
 
-  [Pikaday]:     http://dbushell.github.com/Pikaday/                              "Pikaday"
-  [moment]:      http://momentjs.com/                                             "moment.js"
-  [browserify]:  http://browserify.org/                                           "browserify"
-  [screenshot]:  https://raw.github.com/dbushell/Pikaday/gh-pages/screenshot.png  "Screenshot"
-  [issues]:      https://github.com/dbushell/Pikaday/issues                       "Issue tracker"
-  [gem]:         https://rubygems.org/gems/pikaday-gem                            "RoR gem"
-  [mdn_date]:    https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date  "Date"
-  [Bushell]:     http://dbushell.com/                                             "dbushell.com"
-  [Bushell Twitter]: https://twitter.com/dbushell                                 "@dbushell"
-  [Rikkert]:     https://github.com/rikkert                                       "Rikkert GitHub"
-  [Rikkert Twitter]: https://twitter.com/ramrik                                   "@ramrik"
-  [shoogledesigns]:  https://twitter.com/shoogledesigns/status/255209384261586944 "@shoogledesigns"
-  [issue1]:      https://github.com/dbushell/Pikaday/issues/1                     "Issue 1"
-  [issue18]:     https://github.com/dbushell/Pikaday/issues/18                    "Issue 18"
-  [stas]:        https://github.com/stas                                          "@stas"
-  [stas Pika]:   https://github.com/stas/Pikaday                                  "Pikaday"
-  [owenmead]:     https://github.com/owenmead                                     "@owenmead"
-  [owen Pika]:   https://github.com/owenmead/Pikaday                              "Pikaday"
-  [moment.js example]: http://dbushell.github.com/Pikaday/examples/moment.html    "Pikaday w/ moment.js"
-  [jQuery example]: http://dbushell.github.com/Pikaday/examples/jquery.html       "Pikaday w/ jQuery"
-  [AMD example]: http://dbushell.github.com/Pikaday/examples/amd.html             "Pikaday w/ AMD"
-  [jQuery AMD example]: http://dbushell.github.com/Pikaday/examples/jquery-amd.html "Pikaday w/ jQuery + AMD"
-  [trigger example]: http://dbushell.github.com/Pikaday/examples/trigger.html     "Pikaday using custom trigger"
-  [positions example]: http://dbushell.github.com/Pikaday/examples/positions.html "Pikaday using different position options"
-  [Sugar]:       http://sugarjs.com                                               "Sugar"
-  [Sugar example]: http://dbushell.github.com/Pikaday/examples/sugar.html         "Pikaday w/ Sugar"
+  [Pikaday]:            http://dbushell.github.com/Pikaday/                             "Pikaday"
+  [moment]:             http://momentjs.com/                                            "moment.js"
+  [browserify]:         http://browserify.org/                                          "browserify"
+  [screenshot]:         https://raw.github.com/dbushell/Pikaday/gh-pages/screenshot.png "Screenshot"
+  [issues]:             https://github.com/dbushell/Pikaday/issues                      "Issue tracker"
+  [gem]:                https://rubygems.org/gems/pikaday-gem                           "RoR gem"
+  [mdn_date]:           https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date  "Date"
+  [Bushell]:            http://dbushell.com/                                            "dbushell.com"
+  [Bushell Twitter]:    https://twitter.com/dbushell                                    "@dbushell"
+  [Rikkert]:            https://github.com/rikkert                                      "Rikkert GitHub"
+  [Rikkert Twitter]:    https://twitter.com/ramrik                                      "@ramrik"
+  [shoogledesigns]:     https://twitter.com/shoogledesigns/status/255209384261586944    "@shoogledesigns"
+  [Sugar]:              http://sugarjs.com                                              "Sugar"
+  [Ember]:              http://emberjs.com                                              "Ember"
+  [Knockout]:           http://dbushell.github.com/Pikaday/examples/knockout.html       "Knockout"
+  [issue1]:             https://github.com/dbushell/Pikaday/issues/1                    "Issue 1"
+  [issue18]:            https://github.com/dbushell/Pikaday/issues/18                   "Issue 18"
+  [stas]:               https://github.com/stas                                         "@stas"
+  [stas Pika]:          https://github.com/stas/Pikaday                                 "Pikaday"
+  [owenmead]:           https://github.com/owenmead                                     "@owenmead"
+  [owen Pika]:          https://github.com/owenmead/Pikaday                             "Pikaday"
+  [moment.js example]:  http://dbushell.github.com/Pikaday/examples/moment.html         "Pikaday w/ moment.js"
+  [AMD example]:        http://dbushell.github.com/Pikaday/examples/amd.html            "Pikaday w/ AMD"
+  [jQuery example]:     http://dbushell.github.com/Pikaday/examples/jquery.html         "Pikaday w/ jQuery"
+  [jQuery AMD example]: http://dbushell.github.com/Pikaday/examples/jquery-amd.html     "Pikaday w/ jQuery + AMD"
+  [trigger example]:    http://dbushell.github.com/Pikaday/examples/trigger.html        "Pikaday using custom trigger"
+  [positions example]:  http://dbushell.github.com/Pikaday/examples/positions.html      "Pikaday using different position options"
+  [Sugar example]:      http://dbushell.github.com/Pikaday/examples/sugar.html          "Pikaday w/ Sugar"
+  [Ember example]:      http://dbushell.github.com/Pikaday/examples/ember.html          "Pikaday w/ Ember"
+  [Knockout example]:   http://dbushell.github.com/Pikaday/examples/knockout.html       "Pikaday w/ Knockout"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Pikaday has many useful options:
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
+* `inputFormats` optional array of allowed input formats for `field` value and `.setDate()` with string (requires [Moment.js][moment] for custom parsing). **Note:** The default output `format` will be added to `inputFormats` if not already included. See the [moment.js example][] for example usage.
 * `defaultDate` the initial date to view when first opened
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)
@@ -172,7 +173,7 @@ Returns a basic JavaScript `Date` object of the selected day, or `null` if no se
 
 `picker.setDate('2015-01-01')`
 
-Set the current selection. This will be restricted within the bounds of `minDate` and `maxDate` options if they're specified. If the given date is null or invalid, the current selection is cleared and input field is cleared if `clearInvalidInput` option is `true`. You can optionally pass a boolean as the second parameter to prevent triggering of the onSelect and onClear callbacks (true), allowing the date to be set silently.
+Set the current selection from a date string or Javascript `Date` object. This will be restricted within the bounds of `minDate` and `maxDate` options if they're specified. If the given date is null or invalid, the current selection is cleared (the input field is also cleared if `clearInvalidInput` option is `true`). You can optionally pass a boolean as the second parameter to prevent triggering of the onSelect and onClear callbacks (true), allowing the date to be set silently.
 
 `picker.getMoment()`
 
@@ -185,6 +186,10 @@ Set the current selection with a [Moment.js][moment] object (see `setDate` for d
 `picker.clearDate()`
 
 Clears the current selection. If the first parameter is `true` then the input field (if `field` is set) is also cleared. You can optionally pass a boolean as the second parameter to prevent triggering of the onClear callback (true), allowing the date to be cleared silently.
+
+`picker.parseDate('2015-01-01', ['MM-DD-YY', 'MM-DD-YYYY', 'YYYY-MM-DD'])`
+
+Returns a Javascript `Date` object parsed from the given string. If [Moment.js][moment] exists (recommended) then `.parseDate()` can use Moment to match against one or more formats defined by the second parameter (defaults to the `inputFormats` option).
 
 ### Change current view
 
@@ -255,6 +260,9 @@ i18n: {
 
 You must provide 12 months and 7 weekdays (with abbreviations). Always specify weekdays in this order with Sunday first. You can change the `firstDay` option to reorder if necessary (0: Sunday, 1: Monday, etc). You can also set `isRTL` to `true` for languages that are read right-to-left.
 
+### Custom date parser and formatter functions
+
+Although [Moment.js][moment] is recommended, alternate Javascript Date libraries such as [Sugar][] can be used by overriding `picker.parseDate()` and `picker.toString()` with custom date parser and formatter functions. See the [Sugar example][] for a full example.
 
 ## Extensions
 
@@ -311,3 +319,5 @@ Copyright © 2014 David Bushell | BSD & MIT license
   [jQuery AMD example]: http://dbushell.github.com/Pikaday/examples/jquery-amd.html "Pikaday w/ jQuery + AMD"
   [trigger example]: http://dbushell.github.com/Pikaday/examples/trigger.html     "Pikaday using custom trigger"
   [positions example]: http://dbushell.github.com/Pikaday/examples/positions.html "Pikaday using different position options"
+  [Sugar]:       http://sugarjs.com                                               "Sugar"
+  [Sugar example]: http://dbushell.github.com/Pikaday/examples/sugar.html         "Pikaday w/ Sugar"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Pikaday has many useful options:
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
 * `inputFormats` optional array of allowed input formats for `field` value and `.setDate()` with string (requires [Moment.js][moment] for custom parsing). **Note:** The default output `format` will be added to `inputFormats` if not already included. See the [moment.js example][] for example usage.
-* `defaultDate` the initial date to view when first opened
+* `defaultDate` the initial date to view when first opened (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)
 * `minDate` the minimum/earliest date that can be selected (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Pikaday has many useful options:
 * `i18n` language defaults for month and weekday names (see internationalization below)
 * `yearSuffix` additional text to append to the year in the title
 * `showMonthAfterYear` render the month after year in the title (default `false`)
+* `clearInvalidInput` clear the input field (if `field` is set) on invalid input (default `false`)
 * `onSelect` callback function for when a date is selected
+* `onClear` callback function for when date is set to null or invalid date
 * `onOpen` callback function for when the picker becomes visible
 * `onClose` callback function for when the picker is hidden
 * `onDraw` callback function for when the picker draws a new month
@@ -170,7 +172,7 @@ Returns a basic JavaScript `Date` object of the selected day, or `null` if no se
 
 `picker.setDate('2015-01-01')`
 
-Set the current selection. This will be restricted within the bounds of `minDate` and `maxDate` options if they're specified. You can optionally pass a boolean as the second parameter to prevent triggering of the onSelect callback (true), allowing the date to be set silently.
+Set the current selection. This will be restricted within the bounds of `minDate` and `maxDate` options if they're specified. If the given date is null or invalid, the current selection is cleared and input field is cleared if `clearInvalidInput` option is `true`. You can optionally pass a boolean as the second parameter to prevent triggering of the onSelect and onClear callbacks (true), allowing the date to be set silently.
 
 `picker.getMoment()`
 
@@ -179,6 +181,10 @@ Returns a [Moment.js][moment] object for the selected date (Moment must be loade
 `picker.setMoment(moment('14th February 2014', 'DDo MMMM YYYY'))`
 
 Set the current selection with a [Moment.js][moment] object (see `setDate` for details).
+
+`picker.clearDate()`
+
+Clears the current selection. If the first parameter is `true` then the input field (if `field` is set) is also cleared. You can optionally pass a boolean as the second parameter to prevent triggering of the onClear callback (true), allowing the date to be cleared silently.
 
 ### Change current view
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Returns a basic JavaScript `Date` object of the selected day, or `null` if no se
 
 `picker.setDate('2015-01-01')`
 
-Set the current selection from a date string or Javascript `Date` object. This will be restricted within the bounds of `minDate` and `maxDate` options if they're specified. If the given date is null or invalid, the current selection is cleared (the input field is also cleared if `clearInvalidInput` option is `true`). You can optionally pass a boolean as the second parameter to prevent triggering of the onSelect and onClear callbacks (true), allowing the date to be set silently.
+Set the current selection from a date string or JavaScript `Date` object. This will be restricted within the bounds of `minDate` and `maxDate` options if they're specified. If the given date is null or invalid, the current selection is cleared (the input field is also cleared if `clearInvalidInput` option is `true`). You can optionally pass a boolean as the second parameter to prevent triggering of the onSelect and onClear callbacks (true), allowing the date to be set silently.
 
 `picker.getMoment()`
 
@@ -189,7 +189,7 @@ Clears the current selection. If the first parameter is `true` then the input fi
 
 `picker.parseDate('2015-01-01', ['MM-DD-YY', 'MM-DD-YYYY', 'YYYY-MM-DD'])`
 
-Returns a Javascript `Date` object parsed from the given string. If [Moment.js][moment] exists (recommended) then `.parseDate()` can use Moment to match against one or more formats defined by the second parameter (defaults to the `inputFormats` option).
+Returns a JavaScript `Date` object parsed from the given string. If [Moment.js][moment] exists (recommended) then `.parseDate()` can use Moment to match against one or more formats defined by the second parameter (defaults to the `inputFormats` option).
 
 ### Change current view
 
@@ -262,11 +262,11 @@ You must provide 12 months and 7 weekdays (with abbreviations). Always specify w
 
 ## Custom Date Parsing and Formatting
 
-Although [Moment.js][moment] is recommended, alternate Javascript Date libraries such as [Sugar][] can be used by overriding `parseDate` and `toString` on `Pikaday.prototype` with custom date parser and formatter functions. See the [Sugar example][] for a full example.
+Although [Moment.js][moment] is recommended, other JavaScript Date libraries such as [Datejs][] and [Sugar][]'s Date extension can be used instead by overriding `parseDate` and `toString` on `Pikaday.prototype` with custom date parser and formatter functions. See the [Datejs example][] and [Sugar example][] as a guide.
 
 ## MVC Framework Integration
 
-Pikaday can be easily integrated with most Javascript MVC Frameworks such as [Ember][] and [Knockout][]. See the [Ember example][] and [Knockout example][] for example integrations.
+Pikaday can be easily integrated with most JavaScript MVC Frameworks such as [Ember][] and [Knockout][]. See the [Ember example][] and [Knockout example][] for example integrations.
 
 ## Extensions
 
@@ -306,14 +306,15 @@ Copyright © 2014 David Bushell | BSD & MIT license
   [issues]:             https://github.com/dbushell/Pikaday/issues                      "Issue tracker"
   [gem]:                https://rubygems.org/gems/pikaday-gem                           "RoR gem"
   [mdn_date]:           https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date  "Date"
+  [Datejs]:             http://datejs.com                                               "Datejs"
+  [Sugar]:              http://sugarjs.com                                              "Sugar"
+  [Ember]:              http://emberjs.com                                              "Ember"
+  [Knockout]:           http://knockoutjs.com                                           "Knockout"
   [Bushell]:            http://dbushell.com/                                            "dbushell.com"
   [Bushell Twitter]:    https://twitter.com/dbushell                                    "@dbushell"
   [Rikkert]:            https://github.com/rikkert                                      "Rikkert GitHub"
   [Rikkert Twitter]:    https://twitter.com/ramrik                                      "@ramrik"
   [shoogledesigns]:     https://twitter.com/shoogledesigns/status/255209384261586944    "@shoogledesigns"
-  [Sugar]:              http://sugarjs.com                                              "Sugar"
-  [Ember]:              http://emberjs.com                                              "Ember"
-  [Knockout]:           http://dbushell.github.com/Pikaday/examples/knockout.html       "Knockout"
   [issue1]:             https://github.com/dbushell/Pikaday/issues/1                    "Issue 1"
   [issue18]:            https://github.com/dbushell/Pikaday/issues/18                   "Issue 18"
   [stas]:               https://github.com/stas                                         "@stas"
@@ -326,6 +327,7 @@ Copyright © 2014 David Bushell | BSD & MIT license
   [jQuery AMD example]: http://dbushell.github.com/Pikaday/examples/jquery-amd.html     "Pikaday w/ jQuery + AMD"
   [trigger example]:    http://dbushell.github.com/Pikaday/examples/trigger.html        "Pikaday using custom trigger"
   [positions example]:  http://dbushell.github.com/Pikaday/examples/positions.html      "Pikaday using different position options"
+  [Datejs example]:     http://dbushell.github.com/Pikaday/examples/datejs.html         "Pikaday w/ Datejs"
   [Sugar example]:      http://dbushell.github.com/Pikaday/examples/sugar.html          "Pikaday w/ Sugar"
   [Ember example]:      http://dbushell.github.com/Pikaday/examples/ember.html          "Pikaday w/ Ember"
   [Knockout example]:   http://dbushell.github.com/Pikaday/examples/knockout.html       "Pikaday w/ Knockout"

--- a/examples/datejs.html
+++ b/examples/datejs.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-    <title>Pikaday - Sugar example</title>
+    <title>Pikaday - Datejs example</title>
     <meta name="author" content="Brendan Brewster">
     <link rel="stylesheet" href="../css/pikaday.css">
     <link rel="stylesheet" href="../css/site.css">
@@ -11,17 +11,16 @@
 <body>
     <a href="https://github.com/dbushell/Pikaday"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
 
-    <h1>Pikaday + Sugar</h1>
+    <h1>Pikaday + Datejs</h1>
 
     <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
 
-    <p>Pikaday can be used with JavaScript date libraries other than <a href="http://momentjs.com">moment.js</a>. This example uses custom date parser and formatter functions with the <a href="http://sugarjs.com">Sugar</a> JS library to support natural language parsing (eg 'last wednesday', '2 weeks from monday, 'the end of next month', '1 year from now', '3 months ago') as well as many standard date formats. See Sugar's <a href="http://sugarjs.com/dates">Dates</a> reference page for more examples.</p>
+    <p>Pikaday can be used with JavaScript date libraries other than <a href="http://momentjs.com">moment.js</a>. This example uses the <a href="http://www.datejs.com">Datejs</a> JS library that replaces the native Date parser to support natural language parsing (eg 'tomorrow', '2 weeks ago', '3 months from now', 'next friday') as well as many standard date formats.</p>
 
     <label for="datepicker">Date:</label>
     <br>
     <input type="text" id="datepicker">
     <div><b>Selected:</b> <span id="selected"></span></div>
-    <div><b>Relative:</b> <span id="relative"></span></div>
     <br>
 
     <h2>What is this?</h2>
@@ -30,40 +29,34 @@
 
     <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/bjbrewster">Brendan Brewster</a></p>
 
-    <script src="//cdnjs.cloudflare.com/ajax/libs/sugar/1.4.1/sugar.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/datejs/1.0/date.min.js"></script>
     <script src="../pikaday.js"></script>
     <script>
     // You can override Pikaday's toString() and parseDate() methods to provide
-    // custom date formatting and parsing with other JS libraries such as Sugar.
+    // custom date formatting and parsing with other JS libraries such as Datejs.
 
-    // This example overrides toString() and parseDate() for all Pikaday
-    // instances by updating the Pikaday.prototype.
-
-    Pikaday.prototype.parseDate = function(str) {
-        var date = Date.create(str);
-        return date.isValid() ? date : null;
-    }
+    // Because Datejs replaces the native Date parser, we only need to add a
+    // custom string formatter by overriding 'Pikaday.prototype.toString()' to
+    // format the selected Date using Datejs for all Pikaday instances.
 
     Pikaday.prototype.toString = function(format) {
         var date = this.getDate();
-        return date ? date.format(format || this._o.format) : '';
+        return date ? date.toString(format || this._o.format) : '';
     }
 
     var picker = new Pikaday(
     {
         field: document.getElementById('datepicker'),
         firstDay: 1,
-        format: '{Month} {dd} {yyyy}',
+        format: 'dd MMM yyyy',
         minDate: new Date('2000-01-01'),
         maxDate: new Date('2020-12-31'),
         yearRange: [2000,2020],
         onSelect: function(date) {
-            document.getElementById('selected').innerHTML = this.toString('{Weekday} {Month} {dd}, {yyyy}');
-            document.getElementById('relative').innerHTML = date.relative();
+            document.getElementById('selected').innerHTML = date.toString('D');
         },
         onClear: function() {
             document.getElementById('selected').innerHTML = '';
-            document.getElementById('relative').innerHTML = '';
         }
     });
 

--- a/examples/ember.html
+++ b/examples/ember.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday - Ember example</title>
+    <meta name="author" content="Brendan Brewster">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+</head>
+<body>
+    <a href="https://github.com/dbushell/Pikaday"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+
+    <h1>Pikaday + Ember</h1>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <p>This example shows how Pikaday can be used in an Ember component. The input field is bound to an Ember property that updates the selected text below. The helper buttons show that updating the Ember property also updates the Pikaday instance.</p>
+
+    <script type="text/x-handlebars" data-template-name="index">
+        <label for="datepicker">Date:</label>
+        {{date-input
+            id="datepicker"
+            date=date
+            minDate=minDate
+            maxDate=maxDate
+        }}
+        <div><b>Selected:</b> {{formattedDate}}</div>
+
+        <button {{action gotoToday}}>Today</button>
+        <button {{action clearDate}}>Clear Date</button>
+    </script>
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/bjbrewster">Brendan Brewster</a></p>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0/handlebars.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/1.4.0/ember.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
+    <script src="../pikaday.js"></script>
+    <script>
+    Ember.STRINGS = {
+        date_format: 'DD MMM YYYY',
+        date_input_formats: 'DD MMM YYYY,MMM DD YYYY'
+    }
+
+    App = Ember.Application.create();
+
+    App.IndexController = Ember.ObjectController.extend({
+        minDate: function() { return moment().subtract(3, 'years').toDate(); }.property(),
+        maxDate: function() { return moment().add(3, 'years').toDate(); }.property(),
+
+        formattedDate: function() {
+            var date = this.get('date');
+            return moment(date).format('MMMM Do YYYY');
+        }.property('date'),
+
+        actions: {
+            gotoToday: function() { this.set('date', new Date()); },
+            clearDate: function() { this.set('date', null); }
+        }
+    });
+
+    App.ExampleModel = Ember.Object.extend({
+        date: null
+    });
+
+    App.IndexRoute = Ember.Route.extend({
+        model: function() {
+            return App.ExampleModel.create({ date: moment().add(5, 'days').toDate() });
+        }
+    });
+
+    App.DateInputComponent = Ember.TextField.extend({
+        date: null,
+        minDate: null,
+        maxDate: null,
+        format: null,
+        inputFormats: null,
+        pikaday: null,
+
+        dateDidChange: function() {
+            var date = this.get('date'),
+                pikaday = this.get('pikaday');
+            if (pikaday && !moment(date).isSame(pikaday.getDate())) {
+                pikaday.setDate(date);
+            }
+        }.observes('date'),
+
+        initPikaday: function() {
+            var self = this,
+                format = this.get('format') || Em.String.loc('date_format'),
+                inputFormats = this.get('inputFormats') || Em.String.loc('date_input_formats'),
+                date = moment(this.get('date')),
+                minDate = moment(this.get('minDate')),
+                maxDate = moment(this.get('maxDate')),
+                pikaday = new Pikaday({
+                    field: this.$()[0],
+                    clearInvalidInput: true,
+                    format: format ? format : undefined,
+                    inputFormats: inputFormats ? inputFormats.split(',') : undefined,
+                    setDefaultDate: date.isValid(),
+                    defaultDate: date.isValid() ? date.toDate() : undefined,
+                    minDate: minDate.isValid() ? minDate.toDate() : undefined,
+                    maxDate: maxDate.isValid() ? maxDate.toDate() : undefined,
+                    onSelect: function(date) { self.set('date', date); },
+                    onClear: function() { self.set('date', null); }
+                });
+            this.set('pikaday', pikaday);
+        }.on('didInsertElement')
+    });
+    </script>
+</body>
+</html>

--- a/examples/knockout.html
+++ b/examples/knockout.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday - Knockout example</title>
+    <meta name="author" content="Brendan Brewster">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+</head>
+<body>
+    <a href="https://github.com/dbushell/Pikaday"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+
+    <h1>Pikaday + Knockout</h1>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <p>This example shows how Pikaday can be used in a Knockout binding. The input field is bound to a Knockout observable property that updates the selected text below. The helper buttons show that updating the observable property also updates the Pikaday instance.</p>
+
+    <label for="datepicker">Date:</label>
+    <br>
+    <input
+        type="text"
+        id="datepicker"
+        data-bind="
+            pikaday: date,
+            minDate: minDate,
+            maxDate: maxDate,
+            format: 'DD MMM YYYY',
+            inputFormats: ['DD MMM YYYY', 'MMM DD YYYY']"
+    >
+    <div><b>Selected:</b> <span data-bind="text: formattedDate"></span></div>
+    <br>
+
+    <button data-bind="click: gotoToday">Today</button>
+    <button data-bind="click: clearDate">Clear Date</button>
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/bjbrewster">Brendan Brewster</a></p>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/knockout/3.1.0/knockout-min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
+    <script src="../pikaday.js"></script>
+    <script src="../plugins/pikaday.jquery.js"></script>
+    <script>
+
+    ko.bindingHandlers.pikaday = {
+        init: function(element, valueAccessor, allBindings) {
+            var minDate = moment(ko.unwrap(allBindings.get('minDate') || null)),
+                maxDate = moment(ko.unwrap(allBindings.get('maxDate') || null)),
+                format = ko.unwrap(allBindings.get('format')),
+                inputFormats = ko.unwrap(allBindings.get('inputFormats'));
+
+            $(element).pikaday({
+                format: format,
+                inputFormats: inputFormats,
+                clearInvalidInput: true,
+                minDate: minDate.isValid() ? minDate.toDate() : undefined,
+                maxDate: maxDate.isValid() ? maxDate.toDate() : undefined,
+                onSelect: function(date) { valueAccessor()(date); },
+                onClear: function() { valueAccessor()(null); }
+            });
+        },
+        update: function(element, valueAccessor, allBindings) {
+            var date = ko.unwrap(valueAccessor());
+            $(element).pikaday('setDate', date);
+        }
+    };
+
+    var ViewModel = function() {
+        this.date = ko.observable(moment().add(5, 'days').toDate());
+        this.minDate = moment().subtract(3, 'years').toDate();
+        this.maxDate = moment().add(3, 'years').toDate();
+
+        this.formattedDate = ko.computed(function() {
+            return moment(this.date()).format('MMMM Do YYYY');
+        }, this);
+
+        this.gotoToday = function() { this.date(new Date()); }
+        this.clearDate = function() { this.date(null); }
+    };
+
+    ko.applyBindings(new ViewModel());
+
+    </script>
+</body>
+</html>

--- a/examples/moment.html
+++ b/examples/moment.html
@@ -32,11 +32,14 @@
     <script src="../pikaday.js"></script>
     <script>
 
-    // You can get and set dates with moment objects
+    // You can get and set dates with moment objects.
+    // Multiple input formats can be used with Moment.js via the 'inputFormats' option.
     var picker = new Pikaday(
     {
         field: document.getElementById('datepicker'),
         firstDay: 1,
+        format: 'MMM DD YYYY',
+        inputFormats: ['YY', 'YYYY', 'MM DD', 'MM DD YY', 'MM DD YYYY', 'YYYY MM DD'],
         minDate: new Date('2000-01-01'),
         maxDate: new Date('2020-12-31'),
         yearRange: [2000,2020],
@@ -45,9 +48,9 @@
             document.getElementById('selected').appendChild(date);
         }
     });
-    
+
     picker.setMoment(moment().dayOfYear(366));
-    
+
     </script>
 </body>
 </html>

--- a/examples/sugar.html
+++ b/examples/sugar.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday - Sugar example</title>
+    <meta name="author" content="Brendan Brewster">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+</head>
+<body>
+    <a href="https://github.com/dbushell/Pikaday"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+
+    <h1>Pikaday + Sugar</h1>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <p>Pikaday can be used with custom date parser and date formatter functions. This example uses the <a href="http://sugarjs.com">Sugar</a> Javascript library instead of <a href="http://momentjs.com">Moment.js</a> to support natural language parsing (eg 'last wednesday', '2 weeks from monday, 'the end of next month', '1 year from now', '3 months ago') as well as many standard date formats. See Sugar's <a href="http://sugarjs.com/dates">Dates</a> page for more examples.</p>
+
+    <label for="datepicker">Date:</label>
+    <br>
+    <input type="text" id="datepicker">
+    <div><b>Selected:</b> <span id="selected"></span></div>
+    <div><b>Relative:</b> <span id="relative"></span></div>
+    <br>
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/bjbrewster">Brendan Brewster</a></p>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/sugar/1.4.1/sugar.min.js"></script>
+    <script src="../pikaday.js"></script>
+    <script>
+    // You can override Pikaday's toString() and parseDate() methods to provide
+    // custom date formatting and parsing with an alternate JS library such as Sugar.
+
+    // This example overrides toString() and parseDate() for all Pikaday
+    // instances by updating the Pikaday.prototype.
+
+    Pikaday.prototype.parseDate = function(str) {
+        var date = Date.create(str);
+        return date.isValid() ? date : null;
+    }
+
+    Pikaday.prototype.toString = function() {
+        var date = this.getDate();
+        return date ? date.short() : '';
+    }
+
+    var picker = new Pikaday(
+    {
+        field: document.getElementById('datepicker'),
+        firstDay: 1,
+        minDate: new Date('2000-01-01'),
+        maxDate: new Date('2020-12-31'),
+        yearRange: [2000,2020],
+        onSelect: function(date) {
+            document.getElementById('selected').innerHTML = date.format('{Weekday} {Month} {dd}, {yyyy}');
+            document.getElementById('relative').innerHTML = date.relative();
+        }
+    });
+
+    // Alternatively, you could override toString() and parseDate() for a single
+    // Pikaday instance after initialisation:
+    //
+    // picker.parseDate = function(str) {
+    //     var date = Date.create(str);
+    //     return date.isValid() ? date : null;
+    // }
+    //
+    // picker.toString = function() {
+    //     var date = this.getDate();
+    //     return date ? date.short() : '';
+    // }
+
+    picker.setDate('next friday');
+    </script>
+</body>
+</html>

--- a/pikaday.js
+++ b/pikaday.js
@@ -196,16 +196,20 @@
         minMonth: undefined,
         maxMonth: undefined,
 
+        // reverse the calendar for right-to-left languages
         isRTL: false,
 
-        // Additional text to append to the year in the calendar title
+        // additional text to append to the year in the calendar title
         yearSuffix: '',
 
-        // Render the month after year in the calendar title
+        // render the month after year in the calendar title
         showMonthAfterYear: false,
 
         // how many months are visible (not implemented yet)
         numberOfMonths: 1,
+
+        // clear the input field (if `field` is set) on invalid input
+        clearInvalidInput: false,
 
         // internationalization
         i18n: {
@@ -216,8 +220,9 @@
             weekdaysShort : ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
         },
 
-        // callback function
+        // callback functions
         onSelect: null,
+        onClear: null,
         onOpen: null,
         onClose: null,
         onDraw: null
@@ -614,15 +619,12 @@
          */
         setDate: function(date, preventOnSelect)
         {
-            if (!date) {
-                this._d = null;
-                return this.draw();
-            }
             if (typeof date === 'string') {
                 date = new Date(Date.parse(date));
             }
+
             if (!isDate(date)) {
-                return;
+                return this.clearDate(this._o.clearInvalidInput, preventOnSelect);
             }
 
             var min = this._o.minDate,
@@ -644,6 +646,24 @@
             }
             if (!preventOnSelect && typeof this._o.onSelect === 'function') {
                 this._o.onSelect.call(this, this.getDate());
+            }
+        },
+
+        /**
+         * clear the current selection
+         */
+        clearDate: function(clearField, preventOnClear)
+        {
+            this._d = null;
+            this.draw();
+
+            if (clearField && this._o.field) {
+                this._o.field.value = '';
+                fireEvent(this._o.field, 'change', { firedBy: this });
+            }
+
+            if (!preventOnClear && typeof this._o.onClear === 'function') {
+                this._o.onClear.call(this);
             }
         },
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -781,17 +781,17 @@
                 minMonth = opts.minMonth,
                 maxMonth = opts.maxMonth;
 
-            if (this._y <= minYear) {
+            if (this._y < minYear) {
                 this._y = minYear;
-                if (!isNaN(minMonth) && this._m < minMonth) {
-                    this._m = minMonth;
-                }
+                this._m = minMonth;
+            } else if (this._y == minYear && !isNaN(minMonth) && this._m < minMonth) {
+                this._m = minMonth;
             }
-            if (this._y >= maxYear) {
+            if (this._y > maxYear) {
                 this._y = maxYear;
-                if (!isNaN(maxMonth) && this._m > maxMonth) {
-                    this._m = maxMonth;
-                }
+                this._m = maxMonth;
+            } else if (this._y == maxYear && !isNaN(maxMonth) && this._m > maxMonth) {
+                this._m = maxMonth;
             }
 
             this.el.innerHTML = renderTitle(this) + this.render(this._y, this._m);

--- a/pikaday.js
+++ b/pikaday.js
@@ -607,8 +607,8 @@
                 date = moment(str, format || this._o.inputFormats);
                 date = date.isValid() ? date.toDate() : null;
             } else {
-                date = new Date(Date.parse(str));
-                date = isDate(date) ? date : null;
+                date = Date.parse(str);
+                date = date != null && !isNaN(date) ? new Date(date) : null;
             }
 
             return date;


### PR DESCRIPTION
Thanks for creating this awesome and yet simple date picker. We are using this library on a fundraising portal raising money for charity so know that its helping make a difference in the world. We needed a few changes to make it easier to integrate with Ember.js so I would like to contribute back to your project.

This change is loosely based on #57 to add callback on clear/invalid date and also fixes #61, #48, #15, #93, #98.  I decided upon `onClear` for the name of the callback, in the same vein as `onSelect`, named after the method `clearDate()` that I extracted from `setDate()`. Feel free to suggest better names. It was very tempting to call `onSelect` callback with `null` for empty/invalid date, but this would most likely break a lot of code by the Pikaday community that relies on the callback always having a valid date so a new callback must be introduced instead.  I would also like to add a suite of automated JS tests to improve code quality.
- Cleaned up `setDate()` so both null date and invalid date string clear the current selection.
- Extracted `clearDate()` method from `setDate()` for clearing the current selection with options for clearing the input field (if set) and preventing `onClear` callback.
- `onClear` callback is called by `clearDate()` so users can be notified of invalid/empty date. The user's callback can get the field text value to show a required validation message if empty or invalid date validation message if not empty.
- `onSelect` and `onClear` are useful when integrating with MVC frameworks such as Knockout.js and Ember.js where `onSelect` and `onClear` sets and clears the binding/component's date value. 
- Added examples for Knockout (#48) and Ember.
- `clearInvalidInput` option can be set to `true` to automatically clear the input field value (if `field` is set) on invalid input. This is a simple way of telling the user the entered date is invalid. 
- `parseDate()` method was extracted from `_onInputChange()` to remove duplicate date string parsing in Pikaday constructor for `defaultDate` and in `setDate()` (was only parsing with JS Date.parse?).
- `parseDate()` method was added to Pikaday prototype instead of a helper/private method to allow for overriding both `toString()` and `parseDate()` on Pikaday.prototype to support other JS date libraries. 
  See Datejs and Sugar examples.
- Fixed issue #98 with Datejs where Date.parse() returns null instead of NaN for invalid input which caused a default date of 1/1/1970 in empty input fields.
- A big feature of Moment.js is that it allows for multiple input formats. `inputFormats` option was added to allow users to specify an array of allowed input formats. Defaults to the display format. Moment example updated accordingly.
- Added fix for issue #93 where wrong month is sometimes shown when minDate's year > default selected date. There's a separate issue where setMinDate does not update the internal min/maxMonth and min/maxYear used in `draw` method.
- README updated accordingly (including defaultDate expected type #15)
