### PR TITLE
use pikaday element instead of child element when comparing against trigger element

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -495,12 +495,12 @@
                 }
             }
             do {
-                if (hasClass(pEl, 'pika-single')) {
+                if (pEl === opts.trigger) {
                     return;
                 }
             }
             while ((pEl = pEl.parentNode));
-            if (self._v && target !== opts.trigger) {
+            if (self._v && pEl !== opts.trigger) {
                 self.hide();
             }
         };


### PR DESCRIPTION
This is to fix a bug that occurs when a child element inside the trigger element is clicked. When the child element is clicked, the date picker should still open.
