### PR TITLE
Explicitly set box-sizing for .pika-button's.

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -149,6 +149,8 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 .pika-button {
     cursor: pointer;
     display: block;
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
     outline: none;
     border: 0;
     margin: 0;


### PR DESCRIPTION
If Pikaday is used in some environment that sets box-sizing to something
other than border-box, elements which use .pika-button are rendered
improperly. This commit adds an explicit box-sizing: border-box;
statement to this class to hopefully override some other inherited
box-sizing.
