### PR TITLE
Extra isValid() check with Moment.js  before setting defaultDate()

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -523,7 +523,9 @@
 
             if (!opts.defaultDate) {
                 if (hasMoment && opts.field.value) {
-                    opts.defaultDate = moment(opts.field.value, opts.format).toDate();
+                    if (moment(opts.field.value, opts.format).isValid()) {
+                        opts.defaultDate = moment(opts.field.value, opts.format).toDate();                        
+                    }
                 } else {
                     opts.defaultDate = new Date(Date.parse(opts.field.value));
                 }


### PR DESCRIPTION
When changing the datepicker input value with an invalid date string and then initiating Pikaday. The defaultDate will be set to the minDate.

Case: when you have a HTML5 placeholder polyfill for IE8 (setting the placeholder attribute value to be the value of the value attribute).

Wat goes wrong?
- browser to the website with IE8 and with a placeholder polyfill
- (#datepicker value is set to 'from')
- click on external link
- use the browsers back button
- IE8 remembers the 'from' value and Pikaday sets a wrong date
