### PR TITLE
Clear the <input> value when setDate is passed a falsy value

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -658,6 +658,12 @@
         {
             if (!date) {
                 this._d = null;
+
+                if (this._o.field) {
+                    this._o.field.value = '';
+                    fireEvent(this._o.field, 'change', { firedBy: this });
+                }
+
                 return this.draw();
             }
             if (typeof date === 'string') {


### PR DESCRIPTION
As far as I know, the API doesn't currently have a way to clear the date set in the input. I think this is a reasonable API change and fairly intuitive.
