### PR TITLE
Optional repositioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Pikaday has many useful options:
 * `trigger` use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
+* `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined) 
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
 * `defaultDate` the initial date to view when first opened

--- a/examples/positions.html
+++ b/examples/positions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-    <title>Pikaday alignement example</title>
+    <title>Pikaday alignment example</title>
     <meta name="author" content="Maxime Thirouin">
     <link rel="stylesheet" href="../css/pikaday.css">
     <link rel="stylesheet" href="../css/site.css">
@@ -30,9 +30,11 @@
     <br />
     <input type="text" id="datepicker-bottomright" value="Bottom right (waat?)">
     <br />
+    <input type="text" id="datepicker-bottomright-forced" value="forced to position outside viewport">
+    <br />
     Here is the bottom right position with content before (no automatic adjustment used, , same code as above) <input type="text" id="datepicker-bottomright-forreal" value="Bottom right">
 
-    <p><i>Also, take a look to the bottom right of this page to see an example with position automaticaly adjusted.</i></p>
+    <p><i>Also, take a look to the bottom right of this page to see an example with position automatically adjusted.</i></p>
     <input type="text" id="datepicker-auto" style="position: absolute; bottom: 0; right: 0;" value="Automatic position">
 
     <h2>What is this?</h2>
@@ -79,6 +81,13 @@
     {
         field: document.getElementById('datepicker-bottomright'),
         position: 'bottom right'
+    });
+
+    new Pikaday(
+    {
+        field: document.getElementById('datepicker-bottomright-forced'),
+        position: 'bottom right',
+        reposition: false
     });
 
     new Pikaday(

--- a/pikaday.js
+++ b/pikaday.js
@@ -181,6 +181,9 @@
         // ('bottom' & 'left' keywords are not used, 'top' & 'right' are modifier on the bottom/left position)
         position: 'bottom left',
 
+        // automatically fit in the viewport even if it means repositioning from the position option
+        reposition: true,
+
         // the default output format for `.toString()` and `field` value
         format: 'YYYY-MM-DD',
 
@@ -869,7 +872,7 @@
             }
 
             // default position is bottom & left
-            if (left + width > viewportWidth ||
+            if ((this._o.reposition && left + width > viewportWidth) ||
                 (
                     this._o.position.indexOf('right') > -1 &&
                     left - width + field.offsetWidth > 0
@@ -877,7 +880,7 @@
             ) {
                 left = left - width + field.offsetWidth;
             }
-            if (top + height > viewportHeight + scrollTop ||
+            if ((this._o.reposition && top + height > viewportHeight + scrollTop) ||
                 (
                     this._o.position.indexOf('top') > -1 &&
                     top - height - field.offsetHeight > 0
@@ -885,6 +888,7 @@
             ) {
                 top = top - height - field.offsetHeight;
             }
+
             this.el.style.cssText = [
                 'position: absolute',
                 'left: ' + left + 'px',


### PR DESCRIPTION
Adds an option, `reposition`, which defaults to `true` to leave current behavior.

When set to `false`, it will allow the datepicker to be positioned outside of the current viewport.

The use case is that we need the datepicker to always appear below the input regardless of the input's position on the page so that it does not cover up the label and help text as users are getting confused.
