### PR TITLE
Return false for isVisible() if the el doesn't exist in the dom

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -944,6 +944,10 @@
 
         isVisible: function()
         {
+            if(this.el.offsetParent === null) {
+              return false;
+            }
+            
             return this._v;
         },
 


### PR DESCRIPTION
I'm not sure where exactly `_v` is being set but if pikaday returns true even if the el doesn't exist in the dom.

You can see this happening in this JSBin: http://jsbin.com/zororu/1/edit?html,output