### PR TITLE
Fixed month not updating when outside max/min date

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -813,16 +813,20 @@
                 maxMonth = opts.maxMonth,
                 html = '';
 
-            if (this._y <= minYear) {
-                this._y = minYear;
-                if (!isNaN(minMonth) && this._m < minMonth) {
-                    this._m = minMonth;
+            for (i = 0; i < this.calendars.length; i++) { 
+
+                if (this.calendars[i].year <= minYear) {
+                    this.calendars[i].year = minYear;
+                    if (!isNaN(minMonth) && this.calendars[i].month < minMonth) {
+                        this.calendars[i].month = minMonth;
+                    }
                 }
-            }
-            if (this._y >= maxYear) {
-                this._y = maxYear;
-                if (!isNaN(maxMonth) && this._m > maxMonth) {
-                    this._m = maxMonth;
+
+                if (this.calendars[i].year >= maxYear) {
+                    this.calendars[i].year = maxYear;
+                    if (!isNaN(maxMonth) && this.calendars[i].month > maxMonth) {
+                        this.calendars[i].month = maxMonth;
+                    }
                 }
             }
 


### PR DESCRIPTION
When changing date to the same year as maxYear if the current month was higher than the maxMonth the calendar would break and display the previously selected month (which could be greater the max date) The original code in draw() intending to prevent this doesn't appear to work (looks at variables this._y and this._m which always seem to be undefined and not referenced elsewhere) This fix checks that all calendars are within their max and min dates when changing date.
