### PR TITLE
Fix for bug introduced in #166; fixes #224, #230

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -498,12 +498,12 @@
                 }
             }
             do {
-                if (pEl === opts.trigger) {
+                if (hasClass(pEl, 'pika-single') || pEl === opts.trigger) {
                     return;
                 }
             }
             while ((pEl = pEl.parentNode));
-            if (self._v && pEl !== opts.trigger) {
+            if (self._v && target !== opts.trigger && pEl !== opts.trigger) {
                 self.hide();
             }
         };

--- a/pikaday.js
+++ b/pikaday.js
@@ -475,6 +475,15 @@
 
         self._onInputBlur = function()
         {
+            // IE allows pika div to gain focus; catch blur the input field
+            var pEl = document.activeElement;
+            do {
+                if (hasClass(pEl, 'pika-single')) {
+                    return;
+                }
+            }
+            while ((pEl = pEl.parentNode));
+            
             if (!self._c) {
                 self._b = sto(function() {
                     self.hide();


### PR DESCRIPTION
Changes in #166 broke the click handler's detection of clicks within the pikaday element; for example, clicking on the date drop-downs, as reported in issues #224 and #230.

This change adds the original conditions to the patch in #166. This fixes the introduced bug, while leaving the #166 changes in place to support trigger child elements.