### PR TITLE
bugfox: calendar fails to redraw following a date boundry set

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -788,6 +788,7 @@
         setMinDate: function(value)
         {
             this._o.minDate = value;
+            this.draw();
         },
 
         /**
@@ -796,6 +797,7 @@
         setMaxDate: function(value)
         {
             this._o.maxDate = value;
+            this.draw();
         },
 
         /**


### PR DESCRIPTION
When min or max date is set, the calendar should redraw itself to remove/add the `is-disabled` CSS class to the dates that are now selectable/unselectable due to new date boundries.

Here is a small fiddle to demo the issue: http://jsfiddle.net/xh4uz7x9/1/