### PR TITLE
Make setMinDate() behaviour consistent with the "minDate" option in constructor

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -804,10 +804,10 @@
          */
         setMinDate: function(value)
         {
-            this._o.minDate = value;
             setToStartOfDay(value);
+            this._o.minDate = value;
             this._o.minYear  = value.getFullYear();
-            this._o.minMonth = value.getMonth();            
+            this._o.minMonth = value.getMonth();
         },
 
         /**

--- a/pikaday.js
+++ b/pikaday.js
@@ -489,7 +489,7 @@
                 }
             }
             while ((pEl = pEl.parentNode));
-            
+
             if (!self._c) {
                 self._b = sto(function() {
                     self.hide();
@@ -615,9 +615,7 @@
                 opts.maxDate = opts.minDate = false;
             }
             if (opts.minDate) {
-                setToStartOfDay(opts.minDate);
-                opts.minYear  = opts.minDate.getFullYear();
-                opts.minMonth = opts.minDate.getMonth();
+                this.setMinDate(opts.minDate)
             }
             if (opts.maxDate) {
                 setToStartOfDay(opts.maxDate);
@@ -807,6 +805,9 @@
         setMinDate: function(value)
         {
             this._o.minDate = value;
+            setToStartOfDay(value);
+            this._o.minYear  = value.getFullYear();
+            this._o.minMonth = value.getMonth();            
         },
 
         /**

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -24,6 +24,16 @@ describe('Pikaday public method', function ()
         });
     });
 
+    describe('When specifying minDate option in Constructor', function () {
+        it('Should remove the time portion (flattening to midnight)', function () {
+            var date = new Date(2015, 1, 17, 22, 10, 5),
+                expected = new Date(2015, 1, 17, 0, 0, 0),
+                pikaday = new Pikaday({ minDate: date });
+
+            expect(pikaday._o.minDate).to.eql(expected);
+        });
+    });
+
     describe('#setMinDate()', function () {
         it('should flatten date to midnight ignoring time portion (consistent with minDate option in ctor)', function () {
             var date = new Date(2015, 1, 17, 22, 10, 5),

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -23,4 +23,15 @@ describe('Pikaday public method', function ()
             expect(pikaday.toString()).to.eql('25-04-14');
         });
     });
+
+    describe('#setMinDate()', function () {
+        it('should flatten date to midnight ignoring time portion (consistent with minDate option in ctor)', function () {
+            var date = new Date(2015, 1, 17, 22, 10, 5),
+                expected = new Date(2015, 1, 17, 0, 0, 0),
+                pikaday = new Pikaday();
+
+            pikaday.setMinDate(date);
+            expect(pikaday._o.minDate).to.eql(expected);
+        });
+    });
 });


### PR DESCRIPTION
I ran into an issue that is documented in https://github.com/dbushell/Pikaday/issues/254. I believe the issue manifests when setting min date to a date/time that has a time portion (I noticed it using the current date and time) - the draw function will render the first enabled day as the day after what was passed to setMinDate.

I believe this is due to the constructor removing the time portion but setMinDate() preserves the time. This means that the first conditional at https://github.com/dbushell/Pikaday/blob/master/pikaday.js#L948 will evaluate to false for the previously set min date and evaluate true on the day after the supplied minDate.

This change makes the setMinDate behaviour consistent with that of the constructor "minDate" behaviour.

Bit awkward to explain but hopefully the tests I've added assist with understanding.
