### PR TITLE
Before render hook

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -253,7 +253,8 @@
         onSelect: null,
         onOpen: null,
         onClose: null,
-        onDraw: null
+        onDraw: null,
+        onBeforeRender: null
     },
 
 
@@ -854,6 +855,10 @@
 
             for (var c = 0; c < opts.numberOfMonths; c++) {
                 html += '<div class="pika-lendar">' + renderTitle(this, c, this.calendars[c].year, this.calendars[c].month, this.calendars[0].year) + this.render(this.calendars[c].year, this.calendars[c].month) + '</div>';
+            }
+
+            if (typeof this._o.onBeforeRender === 'function') {
+              html = this._o.onBeforeRender.call(this, html) || html;
             }
 
             this.el.innerHTML = html;

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,0 +1,48 @@
+var Pikaday = require('../'),
+    expect = require('expect.js');
+
+describe('Pikaday option', function ()
+{
+    'use strict';
+
+    describe('onBeforeRender', function ()
+    {
+
+        it('should allow modifying markup', function ()
+        {
+            var origMarkup;
+            var pikaday = new Pikaday({
+                onBeforeRender: function (markup) {
+                    // remember original markup
+                    var container = document.createElement('div');
+                    container.innerHTML = markup;
+                    origMarkup = container.innerHTML;
+
+                    return '<div class="wrapped-by-test">' + markup + '</div>';
+                }
+            });
+            var wrappedByTest = pikaday.el.querySelector('.wrapped-by-test');
+
+            expect(wrappedByTest).to.be.a(HTMLElement);
+            expect(wrappedByTest.innerHTML).to.be(origMarkup);
+        });
+
+        it('should NOT modify markup when nothing is returned', function ()
+        {
+            var origMarkup;
+            var pikaday = new Pikaday({
+                onBeforeRender: function (markup) {
+                    // remember original markup
+                    var container = document.createElement('div');
+                    container.innerHTML = markup;
+                    origMarkup = container.innerHTML;
+
+                    return;
+                }
+            });
+
+            expect(pikaday.el.innerHTML).to.be(origMarkup);
+        });
+
+    });
+});


### PR DESCRIPTION
Adds the ability to modify the markup before it's rendered.

Example:

``` javascript
var pikaday = new Pikaday({
  onBeforeRender: function (markup) {
    return '<div class="wrapped">' + markup + '</div>';
  }
});
```

I'm using this hook to mark a selected date range on the calendar by setting special classes on the corresponding day cells.
