### PR TITLE
Update pikaday.js to fix accessibility/utilisability issue

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -467,7 +467,9 @@
             else {
                 date = new Date(Date.parse(opts.field.value));
             }
-            self.setDate(isDate(date) ? date : null);
+            if (isDate(date)) {
+              self.setDate(date)
+            }
             if (!self._v) {
                 self.show();
             }


### PR DESCRIPTION
This update let the user to type directly into the input field and keep the content.

Without this change, when the user leave the input field, the input will change to a null value which is bad (as the user loose the content he just put into).

### A quick use case example :

    * The user select a date (02-02-2015) with pickaday.
    * Then he just want to change the year. Instead of use pickaday again he decide to direclty type into the field and update the 5 into a 6.
    * Happy of his quick update, he leave the field.
    * Then he loose his selected date
    * He's sad.

