### PR TITLE
Allows now to be set be defaultDate

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -927,7 +927,7 @@
         render: function(year, month)
         {
             var opts   = this._o,
-                now    = new Date(),
+                now    = opts.defaultDate || new Date(),
                 days   = getDaysInMonth(year, month),
                 before = new Date(year, month, 1).getDay(),
                 data   = [],


### PR DESCRIPTION
Allows the current calendar day to be set explicitly rather than relying on client clock.  Useful when you want set today on calendar but not also in bound input field like setDefaultDate option does.