### PR TITLE
Add options flag for strict date parsing with moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Pikaday has many useful options:
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined) 
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
+* `formatStrict` the default flag for moment's strict date parsing (requires [Moment.js][moment] for custom formatting)
 * `defaultDate` the initial date to view when first opened
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)

--- a/pikaday.js
+++ b/pikaday.js
@@ -203,7 +203,7 @@
         firstDay: 0,
 
         // the default flag for moment's strict date parsing
-        formatStrict: undefined,
+        formatStrict: false,
 
         // the minimum/earliest date that can be selected
         minDate: null,

--- a/pikaday.js
+++ b/pikaday.js
@@ -202,6 +202,9 @@
         // first day of week (0: Sunday, 1: Monday etc)
         firstDay: 0,
 
+        // the default flag for moment's strict date parsing
+        formatStrict: undefined,
+
         // the minimum/earliest date that can be selected
         minDate: null,
         // the maximum/latest date that can be selected
@@ -460,7 +463,7 @@
                 return;
             }
             if (hasMoment) {
-                date = moment(opts.field.value, opts.format);
+                date = moment(opts.field.value, opts.format, opts.formatStrict);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }
             else {


### PR DESCRIPTION
Moment's default parser is very forgiving and translates user typed values into unexpected dates.

If the input format is set to "MM/DD/YYYY", and the user inputs "test5" ... Moment will convert the user input into "05/01/2015".

This flag enables Moment's strict parsing.
