### PR TITLE
Added injectMode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .c9revisions
+.idea

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Pikaday has many useful options:
 * `trigger` use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
+* `injectMode` defaults to `relative` (next to the DOM node inside a relative container) or `bottomline` (will append before the closing body tag)
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined) 
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)

--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -5,6 +5,11 @@
  * Copyright © 2014 David Bushell | BSD & MIT license | http://dbushell.com/
  */
 
+.pika-injector {
+    display: block;
+    position: relative;
+}
+
 .pika-single {
     z-index: 9999;
     display: block;
@@ -14,6 +19,10 @@
     border: 1px solid #ccc;
     border-bottom-color: #bbb;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.pika-injector > .pika-single {
+    position: absolute;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
 
     <h2>What is this?</h2>
 
+    <input type="text" id="datepicker2">
+
     <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
 
     <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license</p>
@@ -37,6 +39,17 @@
         maxDate: new Date('2020-12-31'),
         yearRange: [2000,2020]
     });
+
+    var picker2 = new Pikaday(
+          {
+            field: document.getElementById('datepicker2'),
+            firstDay: 1,
+            minDate: new Date('2000-01-01'),
+            maxDate: new Date('2020-12-31'),
+            yearRange: [2000,2020],
+            numberOfMonths: 2,
+            position: 'top left',
+          });
 
     </script>
 </body>

--- a/pikaday.js
+++ b/pikaday.js
@@ -187,6 +187,10 @@
         // ('bottom' & 'left' keywords are not used, 'top' & 'right' are modifier on the bottom/left position)
         position: 'bottom left',
 
+        // injectMode of the datepicker, either next to the DOM node inside a relative container (default)
+        // or bottomline, before the closing body tag
+        injectMode: 'relative',
+
         // automatically fit in the viewport even if it means repositioning from the position option
         reposition: true,
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -540,7 +540,22 @@
             if (opts.container) {
                 opts.container.appendChild(self.el);
             } else if (opts.bound) {
-                document.body.appendChild(self.el);
+                if(opts.injectMode === 'relative') {
+                    self.injector = document.createElement('div');
+                    self.injector.className = 'pika-injector';
+
+                    self.injector.appendChild(self.el);
+
+                    if(!!~opts.position.indexOf('top')) {
+                        opts.field.parentNode.insertBefore(self.injector, opts.field);
+                    } else {
+                        opts.field.parentNode.insertBefore(self.injector, opts.field.nextSibling);
+                    }
+
+                } else {
+                    document.body.appendChild(self.el);
+                }
+
             } else {
                 opts.field.parentNode.insertBefore(self.el, opts.field.nextSibling);
             }

--- a/pikaday.js
+++ b/pikaday.js
@@ -898,49 +898,68 @@
         adjustPosition: function()
         {
             if (this._o.container) return;
-            var field = this._o.trigger, pEl = field,
-            width = this.el.offsetWidth, height = this.el.offsetHeight,
-            viewportWidth = window.innerWidth || document.documentElement.clientWidth,
-            viewportHeight = window.innerHeight || document.documentElement.clientHeight,
-            scrollTop = window.pageYOffset || document.body.scrollTop || document.documentElement.scrollTop,
-            left, top, clientRect;
+            var opts = this._o,
+                field = opts.trigger, pEl = field,
+                width = this.el.offsetWidth, height = this.el.offsetHeight,
+                viewportWidth = window.innerWidth || document.documentElement.clientWidth,
+                viewportHeight = window.innerHeight || document.documentElement.clientHeight,
+                scrollTop = window.pageYOffset || document.body.scrollTop || document.documentElement.scrollTop,
+                left, top, clientRect,
+                cssText = ['position: absolute'];
 
-            if (typeof field.getBoundingClientRect === 'function') {
-                clientRect = field.getBoundingClientRect();
-                left = clientRect.left + window.pageXOffset;
-                top = clientRect.bottom + window.pageYOffset;
-            } else {
-                left = pEl.offsetLeft;
-                top  = pEl.offsetTop + pEl.offsetHeight;
-                while((pEl = pEl.offsetParent)) {
-                    left += pEl.offsetLeft;
-                    top  += pEl.offsetTop;
+            if(opts.injectMode === 'relative') {
+                var positions = opts.position.split(/\s+/),
+                    positionSwap = {
+                        top: 'bottom',
+                        bottom: 'top'
+                    },
+                    position, i, l;
+
+                for(i=0, l=positions.length; i<l; i++) {
+                    position = positions[i];
+
+                    // switch position properties if top or bottom
+                    if(position in positionSwap)
+                        position = positionSwap[position];
+
+                    cssText.push(position + ':0');
                 }
-            }
+            } else {
+                if (typeof field.getBoundingClientRect === 'function') {
+                    clientRect = field.getBoundingClientRect();
+                    left = clientRect.left + window.pageXOffset;
+                    top = clientRect.bottom + window.pageYOffset;
+                } else {
+                    left = pEl.offsetLeft;
+                    top = pEl.offsetTop + pEl.offsetHeight;
+                    while ((pEl = pEl.offsetParent)) {
+                        left += pEl.offsetLeft;
+                        top += pEl.offsetTop;
+                    }
+                }
 
-            // default position is bottom & left
-            if ((this._o.reposition && left + width > viewportWidth) ||
-                (
-                    this._o.position.indexOf('right') > -1 &&
+                // default position is bottom & left
+                if ((opts.reposition && left + width > viewportWidth) ||
+                    (
+                    opts.position.indexOf('right') > -1 &&
                     left - width + field.offsetWidth > 0
-                )
-            ) {
-                left = left - width + field.offsetWidth;
-            }
-            if ((this._o.reposition && top + height > viewportHeight + scrollTop) ||
-                (
-                    this._o.position.indexOf('top') > -1 &&
+                    )
+                ) {
+                    left = left - width + field.offsetWidth;
+                }
+                if ((opts.reposition && top + height > viewportHeight + scrollTop) ||
+                    (
+                    opts.position.indexOf('top') > -1 &&
                     top - height - field.offsetHeight > 0
-                )
-            ) {
-                top = top - height - field.offsetHeight;
+                    )
+                ) {
+                    top = top - height - field.offsetHeight;
+                }
+
+                cssText.push('left: ' + left + 'px', 'top: ' + top + 'px');
             }
 
-            this.el.style.cssText = [
-                'position: absolute',
-                'left: ' + left + 'px',
-                'top: ' + top + 'px'
-            ].join(';');
+            this.el.style.cssText = cssText.join(';');
         },
 
         /**

--- a/pikaday.js
+++ b/pikaday.js
@@ -871,7 +871,10 @@
             }
 
             for (var c = 0; c < opts.numberOfMonths; c++) {
-                html += '<div class="pika-lendar">' + renderTitle(this, c, this.calendars[c].year, this.calendars[c].month, this.calendars[0].year) + this.render(this.calendars[c].year, this.calendars[c].month) + '</div>';
+                html += '<div class="pika-lendar">' +
+                    renderTitle(this, c, this.calendars[c].year, this.calendars[c].month, this.calendars[0].year) +
+                    this.render(this.calendars[c].year, this.calendars[c].month) +
+                '</div>';
             }
 
             this.el.innerHTML = html;


### PR DESCRIPTION
If you bind the datepicker to an input tag it is added before the closing body tag.
Unfortunately this does not work well within scollable DOM nodes.

So I added an injectMode option to fix this issue.
Basically it adds another DIV wrapper before or after the bound input (depending on position option)

Automatic Reposition is not supported sofar, but it would be basically a switch of before and after the input tag.