### PR TITLE
Set style directly instead of using `cssText`

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -914,11 +914,9 @@
                 top = top - height - field.offsetHeight;
             }
 
-            this.el.style.cssText = [
-                'position: absolute',
-                'left: ' + left + 'px',
-                'top: ' + top + 'px'
-            ].join(';');
+            this.el.style.position = 'absolute';
+            this.el.style.left = left + 'px';
+            this.el.style.top = top + 'px';
         },
 
         /**
@@ -998,7 +996,9 @@
                 if (this._o.bound) {
                     removeEvent(document, 'click', this._onClick);
                 }
-                this.el.style.cssText = '';
+                this.el.style.position = 'static'; // reset
+                this.el.style.left = 'auto';
+                this.el.style.top = 'auto';
                 addClass(this.el, 'is-hidden');
                 this._v = false;
                 if (v !== undefined && typeof this._o.onClose === 'function') {


### PR DESCRIPTION
Avoids a Content Security Policy error.

See these two for other examples:
- https://github.com/Modernizr/Modernizr/pull/1263
- https://code.google.com/p/chromium/issues/detail?id=343970