### PR TITLE
Set date on focus

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -476,6 +476,16 @@
 
         self._onInputFocus = function()
         {
+            var date;
+            if(hasMoment) {
+                date = moment(opts.field.value,opts.format);
+                date = (date && date.isValid()) ? date.toDate() : null;
+            } else {
+                date = new Date(Date.parse(opts.field.value));
+            }
+            if(isDate(date)) {
+                self.setDate(date);
+            }
             self.show();
         };
 


### PR DESCRIPTION
Date is set on focus, fixes issues when, if field value was set via JS the date shown would be incorrect when the date picker was next opened.