### PR TITLE
Fix how the width of the popup is calculated.

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -922,7 +922,6 @@
                 top = top - height - field.offsetHeight;
             }
 
-            this.el.style.position = 'absolute';
             this.el.style.left = left + 'px';
             this.el.style.top = top + 'px';
         },

--- a/pikaday.js
+++ b/pikaday.js
@@ -877,13 +877,19 @@
 
         adjustPosition: function()
         {
+            var field, pEl, width, height, viewportWidth, viewportHeight, scrollTop, left, top, clientRect;
+            
             if (this._o.container) return;
-            var field = this._o.trigger, pEl = field,
-            width = this.el.offsetWidth, height = this.el.offsetHeight,
-            viewportWidth = window.innerWidth || document.documentElement.clientWidth,
-            viewportHeight = window.innerHeight || document.documentElement.clientHeight,
-            scrollTop = window.pageYOffset || document.body.scrollTop || document.documentElement.scrollTop,
-            left, top, clientRect;
+            
+            this.el.style.position = 'absolute';
+            
+            field = this._o.trigger;
+            pEl = field;
+            width = this.el.offsetWidth;
+            height = this.el.offsetHeight;
+            viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+            viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+            scrollTop = window.pageYOffset || document.body.scrollTop || document.documentElement.scrollTop;
 
             if (typeof field.getBoundingClientRect === 'function') {
                 clientRect = field.getBoundingClientRect();


### PR DESCRIPTION
Ran into an issue where the popup was being positioned off the screen.  Tracked the problem down to the way the width was being calculated.  The popup was positioned normally before the width was checked which resulted in a full width div.  This resulted in the left point being very negative.  I moved setting the position to absolute before the variables are set to fix this.

This could also be accomplished by updating the stylesheet.