### PR TITLE
Adds option to select a consecutive range of dates.

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -181,6 +181,14 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     border-radius: 3px;
 }
 
+.is-between .pika-button {
+    color: #fff;
+    font-weight: bold;
+    background: #29e;
+    box-shadow: inset 0 1px 3px #178fe5;
+    border-radius: 3px;
+}
+
 .is-disabled .pika-button {
     pointer-events: none;
     cursor: default;


### PR DESCRIPTION
The changes adds a new option `range` that will allow the selection of `start` and `end` dates; useful for things like "I'm taking a vacation from 1/1 to 1/5." Having two calendars isn't as intuitive.