### PR TITLE
Actually disable prev/next month buttons

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -418,10 +418,10 @@
                     }
                     return;
                 }
-                else if (hasClass(target, 'pika-prev')) {
+                else if (hasClass(target, 'pika-prev') && !hasClass(target, 'is-disabled')) {
                     self.prevMonth();
                 }
-                else if (hasClass(target, 'pika-next')) {
+                else if (hasClass(target, 'pika-next') && !hasClass(target, 'is-disabled')) {
                     self.nextMonth();
                 }
             }


### PR DESCRIPTION
Pikaday adds "is-disabled" classes to prev/next month buttons to modify the appearances but doesn't actually checks to disable them.
