### PR TITLE
Move colours and fonts to variables to allow for easy customising

### DIFF
--- a/scss/pikaday.scss
+++ b/scss/pikaday.scss
@@ -3,15 +3,43 @@
  * Copyright © 2014 David Bushell | BSD & MIT license | http://dbushell.com/
  */
 
+// Variables
+// Declare any of these variables before importing this SCSS file to easily override defaults
+// Variables are namespaced with the pd (pikaday) prefix
+
+// Colours
+$pd-text-color: #333 !default;
+$pd-title-color: #333 !default;
+$pd-title-bg: #fff !default;
+$pd-picker-bg: #fff !default;
+$pd-picker-border: #ccc !default;
+$pd-picker-border-bottom: #bbb !default;
+$pd-picker-shadow: rgba(0,0,0,.5) !default;
+$pd-th-color: #999 !default;
+$pd-day-color: #666 !default;
+$pd-day-bg: #f5f5f5 !default;
+$pd-day-hover-color: #fff !default;
+$pd-day-hover-bg: #ff8000 !default;
+$pd-day-today-color: #33aaff !default;
+$pd-day-selected-color: #fff !default;
+$pd-day-selected-bg: #33aaff !default;
+$pd-day-selected-shadow: #178fe5 !default;
+$pd-day-disabled-color: #999 !default;
+$pd-week-color: #999 !default;
+
+// Font
+$pd-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
+
+
 .pika-single {
     z-index: 9999;
     display: block;
     position: relative;
-    color: #333;
-    background: #fff;
-    border: 1px solid #ccc;
-    border-bottom-color: #bbb;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: $pd-text-color;
+    background: $pd-picker-bg;
+    border: 1px solid $pd-picker-border;
+    border-bottom-color: $pd-picker-border-bottom;
+    font-family: $pd-font-family;
 
     &.is-hidden {
         display: none;
@@ -19,7 +47,7 @@
 
     &.is-bound {
         position: absolute;
-        box-shadow: 0 5px 15px -5px rgba(0,0,0,.5);
+        box-shadow: 0 5px 15px -5px $pd-picker-shadow;
     }
 }
 
@@ -70,7 +98,8 @@
     font-size: 14px;
     line-height: 20px;
     font-weight: bold;
-    background-color: #fff;
+    color: $pd-title-color;
+    background-color: $pd-title-bg;
 }
 
 .pika-prev,
@@ -136,7 +165,7 @@
     }
 
     th {
-        color: #999;
+        color: $pd-th-color;
         font-size: 12px;
         line-height: 25px;
         font-weight: bold;
@@ -159,35 +188,35 @@
     margin: 0;
     width: 100%;
     padding: 5px;
-    color: #666;
+    color: $pd-day-color;
     font-size: 12px;
     line-height: 15px;
     text-align: right;
-    background: #f5f5f5;
+    background: $pd-day-bg;
 
     .is-today & {
-        color: #33aaff;
+        color: $pd-day-today-color;
         font-weight: bold;
     }
 
     .is-selected & {
-        color: #fff;
+        color: $pd-day-selected-color;
         font-weight: bold;
-        background: #33aaff;
-        box-shadow: inset 0 1px 3px #178fe5;
+        background: $pd-day-selected-bg;
+        box-shadow: inset 0 1px 3px $pd-day-selected-shadow;
         border-radius: 3px;
     }
 
     .is-disabled & {
         pointer-events: none;
         cursor: default;
-        color: #999;
+        color: $pd-day-disabled-color;
         opacity: .3;
     }
 
     &:hover {
-        color: #fff !important;
-        background: #ff8000 !important;
+        color: $pd-day-hover-color !important;
+        background: $pd-day-hover-bg !important;
         box-shadow: none !important;
         border-radius: 3px !important;
     }
@@ -195,5 +224,5 @@
 
 .pika-week {
     font-size: 11px;
-    color: #999;
+    color: $pd-week-color;
 }


### PR DESCRIPTION
A number of variables have now been added which hold the colours and fonts used in Pikaday. They use the `!default` syntax to allow for overriding before importing the SCSS file. This is similar to how [Bootstrap SASS does it](https://github.com/twbs/bootstrap-sass#sass-1).

For example, I'm using Pikaday in a Rails app. I'm importing the Pikaday SCSS file from its `vendor/components` home, but beforehand I'm setting a few variables to override the defaults. This means I don't need to spend time overriding things and getting into specificity battles (eek `!important`).

Here's a snippet of code from the project I'm using my Pikaday fork in:

```scss
$pd-font-family: Gotham, 'Proxima Nova', 'Helvetica Neue', Arial, sans-serif;
$pd-day-bg: lighten(desaturate($teal, 20%), 60%);
$pd-day-hover-bg: $teal;
$pd-day-today-color: $dull-teal;
$pd-day-selected-bg: $dull-teal;
$pd-day-selected-shadow: darken($pd-day-selected-bg, 10%);

@import "pikaday/scss/pikaday";
```