### PR TITLE
Configurable renderers for month steppers.

### DIFF
--- a/examples/stepper-renderers.html
+++ b/examples/stepper-renderers.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday</title>
+    <meta name="author" content="David Bushell">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+    <style>
+      body > svg {
+        display: none;
+      }
+
+      .pika-prev, .pika-next {
+        /* Override some default pikaday styles in order to show the SVGs */
+        background: none;
+        text-indent: 0px;
+        width: 24px;
+        height: 24px;
+      }
+      .pika-prev > svg, .pika-next > svg {
+        width: 24px;
+        height: 24px;
+        fill: #33aaff;
+      }
+    </style>
+</head>
+<body>
+    <h1>Pikaday</h1>
+    <svg>
+      <symbol viewBox="0 0 24 24" id="icon-prev"><path d="M14.5 20c-.13 0-.26-.05-.35-.15l-8-8c-.1-.09-.15-.22-.15-.35s.05-.26.15-.35l8-8c.2-.2.51-.2.71 0s.2.51 0 .71L7.2 11.5l7.65 7.65c.2.2.2.51 0 .71-.09.09-.22.14-.35.14z"></path></symbol>
+      <symbol viewBox="0 0 24 24" id="icon-next"><path d="M9.5 20c-.13 0-.26-.05-.35-.15-.2-.2-.2-.51 0-.71l7.65-7.65-7.66-7.64c-.2-.2-.2-.51 0-.71s.51-.2.71 0l8 8c.1.1.15.23.15.36s-.05.26-.15.35l-8 8c-.1.1-.23.15-.35.15z"></path></symbol>
+    </svg>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <p><a href="https://github.com/dbushell/Pikaday"><strong>Pikaday source on GitHub</strong></a></p>
+
+    <label for="datepicker">Date:</label>
+    <br>
+    <input type="text" id="datepicker">
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license</p>
+
+
+    <script src="../pikaday.js"></script>
+    <script>
+      var picker,
+          buildSVG;
+
+      buildSVG = function(klass, href) {
+        // Wrap the SVG in a div and disable pointer events to prevent issues
+        // on IE 11.  This also has the side-effect of allowing the Pikaday
+        // handlers to work as expected (they make some assumptions about the
+        // structure of the markup).
+        return '<div class="' + klass + '">' +
+                 '<svg style="pointer-events: none;"><use xlink:href="' + href + '"></use></svg>' +
+               '</div>';
+      };
+
+      picker = new Pikaday({
+        field: document.getElementById('datepicker'),
+        firstDay: 1,
+        minDate: new Date('2000-01-01'),
+        maxDate: new Date('2020-12-31'),
+        yearRange: [2000,2020],
+        renderPreviousStepper: function(enabled, label) {
+          return buildSVG('pika-prev', '#icon-prev');
+        },
+        renderNextStepper: function(enabled, label) {
+          return buildSVG('pika-next', '#icon-next');
+        }
+      });
+    </script>
+</body>
+</html>

--- a/pikaday.js
+++ b/pikaday.js
@@ -172,90 +172,6 @@
         return calendar;
     },
 
-    /**
-     * defaults and localisation
-     */
-    defaults = {
-
-        // bind the picker to a form field
-        field: null,
-
-        // automatically show/hide the picker on `field` focus (default `true` if `field` is set)
-        bound: undefined,
-
-        // position of the datepicker, relative to the field (default to bottom & left)
-        // ('bottom' & 'left' keywords are not used, 'top' & 'right' are modifier on the bottom/left position)
-        position: 'bottom left',
-
-        // automatically fit in the viewport even if it means repositioning from the position option
-        reposition: true,
-
-        // the default output format for `.toString()` and `field` value
-        format: 'YYYY-MM-DD',
-
-        // the initial date to view when first opened
-        defaultDate: null,
-
-        // make the `defaultDate` the initial selected value
-        setDefaultDate: false,
-
-        // first day of week (0: Sunday, 1: Monday etc)
-        firstDay: 0,
-
-        // the minimum/earliest date that can be selected
-        minDate: null,
-        // the maximum/latest date that can be selected
-        maxDate: null,
-
-        // number of years either side, or array of upper/lower range
-        yearRange: 10,
-
-        // show week numbers at head of row
-        showWeekNumber: false,
-
-        // used internally (don't config outside)
-        minYear: 0,
-        maxYear: 9999,
-        minMonth: undefined,
-        maxMonth: undefined,
-
-        isRTL: false,
-
-        // Additional text to append to the year in the calendar title
-        yearSuffix: '',
-
-        // Render the month after year in the calendar title
-        showMonthAfterYear: false,
-
-        // how many months are visible
-        numberOfMonths: 1,
-
-        // when numberOfMonths is used, this will help you to choose where the main calendar will be (default `left`, can be set to `right`)
-        // only used for the first display or when a selected date is not visible
-        mainCalendar: 'left',
-
-        // Specify a DOM element to render the calendar in
-        container: undefined,
-
-        // internationalization
-        i18n: {
-            previousMonth : 'Previous Month',
-            nextMonth     : 'Next Month',
-            months        : ['January','February','March','April','May','June','July','August','September','October','November','December'],
-            weekdays      : ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'],
-            weekdaysShort : ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
-        },
-
-        // Theme Classname
-        theme: null,
-
-        // callback function
-        onSelect: null,
-        onOpen: null,
-        onClose: null,
-        onDraw: null
-    },
-
 
     /**
      * templating functions to abstract HTML rendering
@@ -371,13 +287,21 @@
         }
 
         if (c === 0) {
-            html += '<button class="pika-prev' + (prev ? '' : ' is-disabled') + '" type="button">' + opts.i18n.previousMonth + '</button>';
+            html += opts.renderPreviousStepper(prev, opts.i18n.previousMonth);
         }
         if (c === (instance._o.numberOfMonths - 1) ) {
-            html += '<button class="pika-next' + (next ? '' : ' is-disabled') + '" type="button">' + opts.i18n.nextMonth + '</button>';
+            html += opts.renderNextStepper(next, opts.i18n.nextMonth);
         }
 
         return html += '</div>';
+    },
+
+    renderPreviousStepper = function(enabled, label) {
+        return '<button class="pika-prev' + (enabled ? '' : ' is-disabled') + '" type="button">' + label + '</button>';
+    },
+
+    renderNextStepper = function(enabled, label) {
+        return '<button class="pika-next' + (enabled ? '' : ' is-disabled') + '" type="button">' + label + '</button>';
     },
 
     renderTable = function(opts, data)
@@ -385,6 +309,100 @@
         return '<table cellpadding="0" cellspacing="0" class="pika-table">' + renderHead(opts) + renderBody(data) + '</table>';
     },
 
+    /**
+     * defaults and localisation
+     */
+    defaults = {
+
+        // bind the picker to a form field
+        field: null,
+
+        // automatically show/hide the picker on `field` focus (default `true` if `field` is set)
+        bound: undefined,
+
+        // position of the datepicker, relative to the field (default to bottom & left)
+        // ('bottom' & 'left' keywords are not used, 'top' & 'right' are modifier on the bottom/left position)
+        position: 'bottom left',
+
+        // automatically fit in the viewport even if it means repositioning from the position option
+        reposition: true,
+
+        // the default output format for `.toString()` and `field` value
+        format: 'YYYY-MM-DD',
+
+        // the initial date to view when first opened
+        defaultDate: null,
+
+        // make the `defaultDate` the initial selected value
+        setDefaultDate: false,
+
+        // first day of week (0: Sunday, 1: Monday etc)
+        firstDay: 0,
+
+        // the minimum/earliest date that can be selected
+        minDate: null,
+        // the maximum/latest date that can be selected
+        maxDate: null,
+
+        // number of years either side, or array of upper/lower range
+        yearRange: 10,
+
+        // show week numbers at head of row
+        showWeekNumber: false,
+
+        // used internally (don't config outside)
+        minYear: 0,
+        maxYear: 9999,
+        minMonth: undefined,
+        maxMonth: undefined,
+
+        isRTL: false,
+
+        // Additional text to append to the year in the calendar title
+        yearSuffix: '',
+
+        // Render the month after year in the calendar title
+        showMonthAfterYear: false,
+
+        // how many months are visible
+        numberOfMonths: 1,
+
+        // when numberOfMonths is used, this will help you to choose where the main calendar will be (default `left`, can be set to `right`)
+        // only used for the first display or when a selected date is not visible
+        mainCalendar: 'left',
+
+        // Specify a DOM element to render the calendar in
+        container: undefined,
+
+        // internationalization
+        i18n: {
+            previousMonth : 'Previous Month',
+            nextMonth     : 'Next Month',
+            months        : ['January','February','March','April','May','June','July','August','September','October','November','December'],
+            weekdays      : ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'],
+            weekdaysShort : ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
+        },
+
+        // Theme Classname
+        theme: null,
+
+        // callback function
+        onSelect: null,
+        onOpen: null,
+        onClose: null,
+        onDraw: null,
+
+        // Renderers
+        // Renderers for the previous stepper should ensure that the interactive
+        // element has the class 'pika-prev' and it exists as the top-level
+        // element.
+        renderPreviousStepper: renderPreviousStepper,
+
+        // Renderers for the next stepper should ensure that the interactive
+        // element has the class 'pika-prev' and it exists as the top-level
+        // element.
+        renderNextStepper: renderNextStepper
+    },
 
     /**
      * Pikaday constructor


### PR DESCRIPTION
This adds the ability to provide custom rendering functions for the month stepper elements in the title.  See `examples/stepper-renderers.html` for an example use.