### PR TITLE
Remove non-ascii copyright symbol from CSS

### DIFF
--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -1,8 +1,6 @@
-@charset "UTF-8";
-
 /*!
  * Pikaday
- * Copyright © 2014 David Bushell | BSD & MIT license | http://dbushell.com/
+ * Copyright 2014 David Bushell | BSD & MIT license | http://dbushell.com/
  */
 
 .pika-single {

--- a/scss/pikaday.scss
+++ b/scss/pikaday.scss
@@ -1,6 +1,6 @@
 /*!
  * Pikaday
- * Copyright © 2014 David Bushell | BSD & MIT license | http://dbushell.com/
+ * Copyright 2014 David Bushell | BSD & MIT license | http://dbushell.com/
  */
 
 .pika-single {


### PR DESCRIPTION
Save some bytes, fix some encoding issues with scss compilers. The other option is to add `@charset "UTF-8";` to the scss file too, but I don't think it's worth it for the one character.