### PR TITLE
Change example dates from strings to integers

### DIFF
--- a/examples/amd.html
+++ b/examples/amd.html
@@ -39,8 +39,8 @@
         {
             field: document.getElementById('datepicker'),
             firstDay: 1,
-            minDate: new Date('2000-01-01'),
-            maxDate: new Date('2020-12-31'),
+            minDate: new Date(2000, 0, 1),
+            maxDate: new Date(2020, 12, 31),
             yearRange: [2000,2020]
         });
     });

--- a/examples/bound-container.html
+++ b/examples/bound-container.html
@@ -40,8 +40,8 @@
     {
         field: document.getElementById('datepicker'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000, 2020],
         bound: true,
         container: document.getElementById('container'),

--- a/examples/calendars.html
+++ b/examples/calendars.html
@@ -36,8 +36,8 @@
         numberOfMonths: 2,
         field: document.getElementById('datepicker-2months'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000, 2020]
     });
 
@@ -47,8 +47,8 @@
         mainCalendar: 'right',
         field: document.getElementById('datepicker-3months-right'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000, 2020]
     });
 

--- a/examples/container.html
+++ b/examples/container.html
@@ -40,8 +40,8 @@
     {
         field: document.getElementById('datepicker'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000, 2020],
         bound: false,
         container: document.getElementById('container'),

--- a/examples/jquery-amd.html
+++ b/examples/jquery-amd.html
@@ -41,8 +41,8 @@
     {
         var $datepicker = $('#datepicker').pikaday({
             firstDay: 1,
-            minDate: new Date('2000-01-01'),
-            maxDate: new Date('2020-12-31'),
+            minDate: new Date(2000, 0, 1),
+            maxDate: new Date(2020, 12, 31),
             yearRange: [2000,2020]
         });
         // chain a few methods for the first datepicker, jQuery style!

--- a/examples/jquery.html
+++ b/examples/jquery.html
@@ -34,8 +34,8 @@
 
     var $datepicker = $('#datepicker').pikaday({
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000,2020]
     });
     // chain a few methods for the first datepicker, jQuery style!

--- a/examples/moment.html
+++ b/examples/moment.html
@@ -37,8 +37,8 @@
     {
         field: document.getElementById('datepicker'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000,2020],
         onSelect: function() {
             var date = document.createTextNode(this.getMoment().format('Do MMMM YYYY') + ' ');

--- a/examples/trigger.html
+++ b/examples/trigger.html
@@ -36,8 +36,8 @@
     {
         field: document.getElementById('datepicker'),
         trigger: document.getElementById('datepicker-button'),
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2010,2020]
     });
 

--- a/examples/weeknumbers.html
+++ b/examples/weeknumbers.html
@@ -31,8 +31,8 @@
         showWeekNumber: true,
         field: document.getElementById('datepicker-week-numbers'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000, 2020]
     });
 

--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
     {
         field: document.getElementById('datepicker'),
         firstDay: 1,
-        minDate: new Date('2000-01-01'),
-        maxDate: new Date('2020-12-31'),
+        minDate: new Date(2000, 0, 1),
+        maxDate: new Date(2020, 12, 31),
         yearRange: [2000,2020]
     });
 


### PR DESCRIPTION
The examples use Date constructors like this: `new Date('2000-01-01')`. Date strings without timezone information are parsed as UTC. Internally, Pikaday uses the integer form: `new Date(2000, 0, 1)`, which creates a date with the local timezone. This means the discrepancy of minDate, maxDate, defaultDate, etc. can be up to 12(13?) hours from what's expected.

This causes confusion like #138 and #267, and seemingly off by one bugs (that aren't really bugs) like this [JSFiddle](http://jsfiddle.net/vjmsvn03/) if you load it in UTC-06:00 before noon. Here's a screenshot for others:

![screenshot](http://i.imgur.com/dYh2Rdy.png)

Might be good to add a note to the readme too.