### PR TITLE
Go to earliest or latest available date

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -563,7 +563,15 @@
                 self.gotoDate(defDate);
             }
         } else {
-            self.gotoDate(new Date());
+            defDate = new Date();
+
+            if (opts.minDate && opts.minDate > defDate) {
+                defDate = opts.minDate;
+            } else if (opts.maxDate && opts.maxDate < defDate) {
+                defDate = opts.maxDate;
+            }
+
+            self.gotoDate(defDate);
         }
 
         if (opts.bound) {


### PR DESCRIPTION
Instead of defaulting to today `new Date()` when today is not in the minDate/maxDate range, it's better to go to the minDate (or maxDate) so that dates are selectable in the current month. Issue is described here #321.