### PR TITLE
Don't blur field after selecting date

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -411,9 +411,6 @@
                     if (opts.bound) {
                         sto(function() {
                             self.hide();
-                            if (opts.field) {
-                                opts.field.blur();
-                            }
                         }, 100);
                     }
                     return;


### PR DESCRIPTION
This reverts the behavior from #94, since I believe the tabbing issue #346 is more important than the datepicker showing again when the field regains focus after switching tabs. Open to other ideas though.