### PR TITLE
remove format option from parsing entered date if using momentjs

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -472,7 +472,7 @@
                 return;
             }
             if (hasMoment) {
-                date = moment(opts.field.value, opts.format);
+                date = moment(opts.field.value);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }
             else {


### PR DESCRIPTION
I see inconsistency in handling `_onInputChange` event. If we use moment.js, the parsing has specified `format` option, but if we do not use moment.js, we parse the input by `Date.parse` without specified `format` option.

Furthermore, the `format` option, according to docs and comments in code, is used as **default output format**, not input.

Eventually it gives us scenario in which the library cannot properly parse multiple format options (like `20/06/2015`, `20 JUN 2015`, etc.) to the same date. This feature is a great value of Pikaday and IMO should be accessible.