### PR TITLE
fix repositioning bug to avoid negative left position

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -944,7 +944,7 @@
                 top = top - height - field.offsetHeight;
             }
 
-            this.el.style.left = left + 'px';
+            this.el.style.left = Math.max(0, left) + 'px';
             this.el.style.top = top + 'px';
         },
 


### PR DESCRIPTION
I was still getting negative values for small windows as discussed in issue #304 even after the fix in #298 was merged in. Setting the minimum left position to 0 fixes this for me.