### PR TITLE
Add 'blurOnSelect' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Pikaday has many useful options:
 * `field` bind the datepicker to a form field
 * `trigger` use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
+* `blurOnSelect` automatically blur the form field when a date is selected (default `true` if `field` is set)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined) 

--- a/pikaday.js
+++ b/pikaday.js
@@ -183,6 +183,9 @@
         // automatically show/hide the picker on `field` focus (default `true` if `field` is set)
         bound: undefined,
 
+        // automatically blur the form field when a date is selected
+        blurOnSelect: true,
+
         // position of the datepicker, relative to the field (default to bottom & left)
         // ('bottom' & 'left' keywords are not used, 'top' & 'right' are modifier on the bottom/left position)
         position: 'bottom left',
@@ -423,7 +426,7 @@
                     if (opts.bound) {
                         sto(function() {
                             self.hide();
-                            if (opts.field) {
+                            if (opts.field && opts.blurOnSelect) {
                                 opts.field.blur();
                             }
                         }, 100);


### PR DESCRIPTION
When you select a date from Pikaday, it blurs the field that it's bound to, preventing the user from tabbing to the next field. I needed the ability to disable this, so I added a 'blurOnSelect' option that defaults to true (keeping the existing behavior).

Thanks for your awesome datepicker!