### PR TITLE
Remove jQuery data attribute after Pikaday instance is destroyed

### DIFF
--- a/plugins/pikaday.jquery.js
+++ b/plugins/pikaday.jquery.js
@@ -44,6 +44,10 @@
             } else {
                 if (typeof args[0] === 'string' && typeof plugin[args[0]] === 'function') {
                     plugin[args[0]].apply(plugin, Array.prototype.slice.call(args,1));
+
+                    if (args[0] === 'destroy') {
+                        self.removeData('pikaday');
+                    }
                 }
             }
         });


### PR DESCRIPTION
Makes the behavior consistent with vanilla Pikaday (instances can be destroyed and re-created without side effects)

Thanks for reporting #382 @Muffinman