### PR TITLE
fix to prevent setting absolute position to static for bound pickers,…

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -1073,7 +1073,9 @@
                 if (this._o.bound) {
                     removeEvent(document, 'click', this._onClick);
                 }
-                this.el.style.position = 'static'; // reset
+                else{
+                    this.el.style.position = 'static'; // reset
+                }                
                 this.el.style.left = 'auto';
                 this.el.style.top = 'auto';
                 addClass(this.el, 'is-hidden');


### PR DESCRIPTION
… which can throw off positioning calculations

For bound pickers which rely on absolute positioning, setting the element position to static within the hide() function can break the adjustPosition() calculations, which leads to the picker appearing far from the bound element, or entirely off screen, as the css left property will contain extreme values.  

As an aside, for absolutely positioned (bound) pickers, it seems there is no purpose for setting back to static anyway.  An alternative could be to set position = '', but I think this solution makes slightly more sense.