### PR TITLE
When click previousMonth, nextMonth check for class existence also on parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ i18n: {
 
 You must provide 12 months and 7 weekdays (with abbreviations). Always specify weekdays in this order with Sunday first. You can change the `firstDay` option to reorder if necessary (0: Sunday, 1: Monday, etc). You can also set `isRTL` to `true` for languages that are read right-to-left.
 
+`previousMonth` and `nextMonth` support custom HTML, which lets you customise the way previous and next month options look, e.g.
+
+```javascript
+i18n: {
+    previousMonth : '<span>Prev</span>',
+    ...
+}
+```
 
 ## Extensions
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -85,6 +85,18 @@
         return (' ' + el.className + ' ').indexOf(' ' + cn + ' ') !== -1;
     },
 
+    /**
+     * Check if any of the parents has the specifid class.
+     * @param {Element} el The target element.
+     * @param {string} cn The class to check for.
+     * @returns {boolean} True if any of the parents has the specified class.
+     */
+    parentHasClass = function(el, cn)
+    {
+        while ((el = el.parentElement) && !hasClass(el, cn));
+        return !!el;
+    },
+
     addClass = function(el, cn)
     {
         if (!hasClass(el, cn)) {
@@ -439,10 +451,10 @@
                         }, 100);
                     }
                 }
-                else if (hasClass(target, 'pika-prev')) {
+                else if (hasClass(target, 'pika-prev') || parentHasClass(target, 'pika-prev')) {
                     self.prevMonth();
                 }
-                else if (hasClass(target, 'pika-next')) {
+                else if (hasClass(target, 'pika-next') || parentHasClass(target, 'pika-next')) {
                     self.nextMonth();
                 }
             }
@@ -510,12 +522,9 @@
         {
             // IE allows pika div to gain focus; catch blur the input field
             var pEl = document.activeElement;
-            do {
-                if (hasClass(pEl, 'pika-single')) {
-                    return;
-                }
+            if (parentHasClass(pEl, 'pika-single')) {
+                return;
             }
-            while ((pEl = pEl.parentNode));
 
             if (!self._c) {
                 self._b = sto(function() {
@@ -539,8 +548,11 @@
                     addEvent(target, 'change', self._onChange);
                 }
             }
+            if (parentHasClass(pEl, 'pika-single')) {
+                return;
+            }
             do {
-                if (hasClass(pEl, 'pika-single') || pEl === opts.trigger) {
+                if (pEl === opts.trigger) {
                     return;
                 }
             }


### PR DESCRIPTION
When providing custom HTML for `previousMonth`, `nextMonth` in i18n options, the `prevMonth()` and `nextMonth()` were not executed as the actual element did not contain the `pika-prev` or `pika-next` classes. To not depend on using these classes, we check for the existence of these classes in parents of the target element.

For example adding the `pika-prev` class does not work in the following case

``` javascript
i18n: {
    "previousMonth": `
        <svg class="icon pika-prev">
            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="icons.svg#arrow_right"></use>
        </svg>
    `,
    ...
}
```
