### PR TITLE
Add possibility to reset the max and min date to the date picker.

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -841,6 +841,7 @@
                 this._o.minDate = defaults.minDate;
                 this._o.minYear  = defaults.minYear;
                 this._o.minMonth = defaults.minMonth;
+                this._o.startRange = defaults.startRange;
             }
 
             this.draw();
@@ -860,6 +861,7 @@
                 this._o.maxDate = defaults.maxDate;
                 this._o.maxYear = defaults.maxYear;
                 this._o.maxMonth = defaults.maxMonth;
+                this._o.endRange = defaults.endRange;
             }
 
             this.draw();

--- a/pikaday.js
+++ b/pikaday.js
@@ -832,7 +832,7 @@
          */
         setMinDate: function(value)
         {
-            if(value) {
+            if(value instanceof Date) {
                 setToStartOfDay(value);
                 this._o.minDate = value;
                 this._o.minYear  = value.getFullYear();
@@ -852,7 +852,7 @@
          */
         setMaxDate: function(value)
         {
-            if(value) {
+            if(value instanceof Date) {
                 setToStartOfDay(value);
                 this._o.maxDate = value;
                 this._o.maxYear = value.getFullYear();

--- a/pikaday.js
+++ b/pikaday.js
@@ -832,10 +832,17 @@
          */
         setMinDate: function(value)
         {
-            setToStartOfDay(value);
-            this._o.minDate = value;
-            this._o.minYear  = value.getFullYear();
-            this._o.minMonth = value.getMonth();
+            if(value) {
+                setToStartOfDay(value);
+                this._o.minDate = value;
+                this._o.minYear  = value.getFullYear();
+                this._o.minMonth = value.getMonth();
+            } else {
+                this._o.minDate = defaults.minDate;
+                this._o.minYear  = defaults.minYear;
+                this._o.minMonth = defaults.minMonth;
+            }
+
             this.draw();
         },
 
@@ -844,10 +851,17 @@
          */
         setMaxDate: function(value)
         {
-            setToStartOfDay(value);
-            this._o.maxDate = value;
-            this._o.maxYear = value.getFullYear();
-            this._o.maxMonth = value.getMonth();
+            if(value) {
+                setToStartOfDay(value);
+                this._o.maxDate = value;
+                this._o.maxYear = value.getFullYear();
+                this._o.maxMonth = value.getMonth();
+            } else {
+                this._o.maxDate = defaults.maxDate;
+                this._o.maxYear = defaults.maxYear;
+                this._o.maxMonth = defaults.maxMonth;
+            }
+
             this.draw();
         },
 


### PR DESCRIPTION
The changes allow to **reset the maximum and minimum date**. A typical use case for this feature is when you use two datepicker to select a range and **one or both bounds are optionnal** (the date-range.html example with enhancements). When setting the optional value to null it was not possible to remove the range limitation.