### PR TITLE
Week mode: Pick a whole week instead of a day

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Pikaday has many useful options:
 * `disableDayFn` callback function that gets passed a Date object for each day in view. Should return true to disable selection of that day.
 * `yearRange` number of years either side (e.g. `10`) or array of upper/lower range (e.g. `[1900,2015]`)
 * `showWeekNumber` show the ISO week number at the head of the row (default `false`)
-* `weekMode` select a whole week instead of a day (default `false`)
+* `pickWholeWeek` select a whole week instead of a day (default `false`)
 * `isRTL` reverse the calendar for right-to-left languages
 * `i18n` language defaults for month and weekday names (see internationalization below)
 * `yearSuffix` additional text to append to the year in the title

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Pikaday has many useful options:
 * `disableDayFn` callback function that gets passed a Date object for each day in view. Should return true to disable selection of that day.
 * `yearRange` number of years either side (e.g. `10`) or array of upper/lower range (e.g. `[1900,2015]`)
 * `showWeekNumber` show the ISO week number at the head of the row (default `false`)
+* `weekMode` select a whole week instead of a day (default `false`)
 * `isRTL` reverse the calendar for right-to-left languages
 * `i18n` language defaults for month and weekday names (see internationalization below)
 * `yearSuffix` additional text to append to the year in the title

--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -214,7 +214,8 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     opacity: .3;
 }
 
-.pika-button:hover {
+.pika-button:hover,
+.pika-row.week-mode:hover .pika-button {
     color: #fff;
     background: #ff8000;
     box-shadow: none;

--- a/css/pikaday.css
+++ b/css/pikaday.css
@@ -215,7 +215,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 }
 
 .pika-button:hover,
-.pika-row.week-mode:hover .pika-button {
+.pika-row.pick-whole-week:hover .pika-button {
     color: #fff;
     background: #ff8000;
     box-shadow: none;

--- a/examples/pick-whole-week.html
+++ b/examples/pick-whole-week.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <title>Pikaday - pickWholeWeek example</title>
+    <meta name="author" content="Lei Zhao">
+    <link rel="stylesheet" href="../css/pikaday.css">
+    <link rel="stylesheet" href="../css/site.css">
+</head>
+<body>
+    <a href="https://github.com/dbushell/Pikaday"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+
+    <h1>Pikaday - pickWholeWeek example</h1>
+
+    <p class="large">A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS.</p>
+
+    <label for="datepicker">Date:</label>
+    <br>
+    <input type="text" id="datepicker">
+
+    <h2>What is this?</h2>
+
+    <p>Since version 1.0 Pikaday is a stable and battle tested date-picker. Feel free to use it however you like but please report any bugs or feature requests to the <a href="https://github.com/dbushell/Pikaday/issues">GitHub issue tracker</a>, thanks!</p>
+
+    <p class="small">Copyright © 2014 <a href="http://dbushell.com/">David Bushell</a> | BSD &amp; MIT license | Example by <a href="https://github.com/leizhao4">Lei Zhao</a></p>
+
+    <script src="../pikaday.js"></script>
+    <script>
+
+    var field = document.getElementById('datepicker');
+    var picker = new Pikaday({
+        field: field,
+        pickWholeWeek: true,
+        onSelect: function (date) {
+            var sundayDate = date.getDate() - date.getDay();
+            var sunday = new Date(date.setDate(sundayDate));
+            var saturday = new Date(date.setDate(sundayDate + 6));
+            field.value = sunday.toLocaleDateString() + ' - ' + saturday.toLocaleDateString();
+        }
+    });
+
+    </script>
+</body>
+</html>

--- a/pikaday.js
+++ b/pikaday.js
@@ -217,7 +217,7 @@
         showWeekNumber: false,
 
         // Week picker mode
-        weekMode: false,
+        pickWholeWeek: false,
 
         // used internally (don't config outside)
         minYear: 0,
@@ -335,9 +335,9 @@
         return '<td class="pika-week">' + weekNum + '</td>';
     },
 
-    renderRow = function(days, isRTL, weekMode, isRowSelected)
+    renderRow = function(days, isRTL, pickWholeWeek, isRowSelected)
     {
-        return '<tr class="pika-row ' + (weekMode ? ' week-mode' : '') + (isRowSelected ? ' is-selected' : '') + '">' + (isRTL ? days.reverse() : days).join('') + '</tr>';
+        return '<tr class="pika-row ' + (pickWholeWeek ? ' pick-whole-week' : '') + (isRowSelected ? ' is-selected' : '') + '">' + (isRTL ? days.reverse() : days).join('') + '</tr>';
     },
 
     renderBody = function(rows)
@@ -1128,7 +1128,7 @@
                         showDaysInNextAndPreviousMonths: opts.showDaysInNextAndPreviousMonths
                     };
 
-                if (opts.weekMode && isSelected) {
+                if (opts.pickWholeWeek && isSelected) {
                     isWeekSelected = true;
                 }
 
@@ -1138,7 +1138,7 @@
                     if (opts.showWeekNumber) {
                         row.unshift(renderWeek(i - before, month, year));
                     }
-                    data.push(renderRow(row, opts.isRTL, opts.weekMode, isWeekSelected));
+                    data.push(renderRow(row, opts.isRTL, opts.pickWholeWeek, isWeekSelected));
                     row = [];
                     r = 0;
                     isWeekSelected = false;

--- a/pikaday.js
+++ b/pikaday.js
@@ -335,9 +335,9 @@
         return '<td class="pika-week">' + weekNum + '</td>';
     },
 
-    renderRow = function(days, isRTL, isRowSelected)
+    renderRow = function(days, isRTL, weekMode, isRowSelected)
     {
-        return '<tr' + (isRowSelected ? ' class="is-selected"' : '') + '>' + (isRTL ? days.reverse() : days).join('') + '</tr>';
+        return '<tr class="pika-row ' + (weekMode ? ' week-mode' : '') + (isRowSelected ? ' is-selected' : '') + '">' + (isRTL ? days.reverse() : days).join('') + '</tr>';
     },
 
     renderBody = function(rows)
@@ -1138,7 +1138,7 @@
                     if (opts.showWeekNumber) {
                         row.unshift(renderWeek(i - before, month, year));
                     }
-                    data.push(renderRow(row, opts.isRTL, isWeekSelected));
+                    data.push(renderRow(row, opts.isRTL, opts.weekMode, isWeekSelected));
                     row = [];
                     r = 0;
                     isWeekSelected = false;

--- a/pikaday.js
+++ b/pikaday.js
@@ -337,7 +337,7 @@
 
     renderRow = function(days, isRTL, pickWholeWeek, isRowSelected)
     {
-        return '<tr class="pika-row ' + (pickWholeWeek ? ' pick-whole-week' : '') + (isRowSelected ? ' is-selected' : '') + '">' + (isRTL ? days.reverse() : days).join('') + '</tr>';
+        return '<tr class="pika-row' + (pickWholeWeek ? ' pick-whole-week' : '') + (isRowSelected ? ' is-selected' : '') + '">' + (isRTL ? days.reverse() : days).join('') + '</tr>';
     },
 
     renderBody = function(rows)

--- a/pikaday.js
+++ b/pikaday.js
@@ -216,6 +216,9 @@
         // show week numbers at head of row
         showWeekNumber: false,
 
+        // Week picker mode
+        weekMode: false,
+
         // used internally (don't config outside)
         minYear: 0,
         maxYear: 9999,
@@ -332,9 +335,9 @@
         return '<td class="pika-week">' + weekNum + '</td>';
     },
 
-    renderRow = function(days, isRTL)
+    renderRow = function(days, isRTL, isRowSelected)
     {
-        return '<tr>' + (isRTL ? days.reverse() : days).join('') + '</tr>';
+        return '<tr' + (isRowSelected ? ' class="is-selected"' : '') + '>' + (isRTL ? days.reverse() : days).join('') + '</tr>';
     },
 
     renderBody = function(rows)
@@ -1079,6 +1082,7 @@
                 after -= 7;
             }
             cells += 7 - after;
+            var isWeekSelected = false;
             for (var i = 0, r = 0; i < cells; i++)
             {
                 var day = new Date(year, month, 1 + (i - before)),
@@ -1124,15 +1128,20 @@
                         showDaysInNextAndPreviousMonths: opts.showDaysInNextAndPreviousMonths
                     };
 
+                if (opts.weekMode && isSelected) {
+                    isWeekSelected = true;
+                }
+
                 row.push(renderDay(dayConfig));
 
                 if (++r === 7) {
                     if (opts.showWeekNumber) {
                         row.unshift(renderWeek(i - before, month, year));
                     }
-                    data.push(renderRow(row, opts.isRTL));
+                    data.push(renderRow(row, opts.isRTL, isWeekSelected));
                     row = [];
                     r = 0;
+                    isWeekSelected = false;
                 }
             }
             return renderTable(opts, data, randId);


### PR DESCRIPTION
I added a new option `pickWholeWeek`. When set to `true`, instead of picking a day, you can pick a whole week. Hope it helps.

Note: I didn't change a lot to the original implementation. Technically you are still picking one day, but the entire row is highlighted. You will need to calculate your week's start and end. See the example for details.
