### PR TITLE
Don't open on change when trigger set.

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -522,7 +522,7 @@
             if (isDate(date)) {
               self.setDate(date);
             }
-            if (!self._v) {
+            if (!self._v && !opts.trigger) {
                 self.show();
             }
         };


### PR DESCRIPTION
When trigger is set, the Pikaday window should not be opened whenever a change is made to the bound field.  Simply then show() should not be called in _onInputChange when trigger is set.