### PR TITLE
Add debounce option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Pikaday has many useful options:
 * `field` bind the datepicker to a form field
 * `trigger` use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
+* `debounce` delays update of Pickaday window when adjusting text field
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined)

--- a/pikaday.js
+++ b/pikaday.js
@@ -505,7 +505,22 @@
             }
         };
 
-        self._onInputChange = function(e)
+        var debounce;
+
+        self._onInputChange = function (e) {
+            if (!opts.debounce) {
+                return onInputChange(e);
+            }
+            if (debounce) {
+                clearTimeout(debounce);
+            }
+            debounce = setTimeout(function () {
+                debounce = null;
+                onInputChange(e);
+            }, opts.debounce);
+        };
+
+        function onInputChange(e)
         {
             var date;
 
@@ -525,7 +540,7 @@
             if (!self._v) {
                 self.show();
             }
-        };
+        }
 
         self._onInputFocus = function()
         {


### PR DESCRIPTION
Pikaday's _onInputChange attempts to update the calendar whenever a change takes place to the input field.  This is counterproductive when typing a date that may be invalid in the midst of typing (the invalid date is processed and then cleared by Pikaday).

It makes sense to debounce the _onInputChange call when it is assumed that users will try to type dates as an option to using the calendar input (e.g. when using a trigger). This patch adds a debounce option with a prescribed delay (e.g. 333ms).