### PR TITLE
shifting the dates one day when using firstDay: 1

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -1067,7 +1067,7 @@
             cells += 7 - after;
             for (var i = 0, r = 0; i < cells; i++)
             {
-                var day = new Date(year, month, 1 + (i - before)),
+                var day = new Date(year, month, 1 + (i - before) + opts.firstDay),
                     isSelected = isDate(this._d) ? compareDates(day, this._d) : false,
                     isToday = compareDates(day, now),
                     isEmpty = i < before || i >= (days + before),


### PR DESCRIPTION
When using `disableDayFn` and `firstDay: 1`, all the dates are shifted one day into the future.
So when I wanted to disable '2016-06-10', it was actually disabling '2016-06-11'.