### PR TITLE
fix the refresh html error when the instance is not bound to a field

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -982,7 +982,11 @@
                 this._o.onDraw(this);
             }
           // let the screen reader user know to use arrow keys
-          this._o.field.setAttribute('aria-label', 'Use the arrow keys to pick a date');
+          if(this._o.field){
+              this._o.field.setAttribute('aria-label', 'Use the arrow keys to pick a date');
+          }else {
+              this.el.setAttribute('aria-label', 'Use the arrow keys to pick a date');
+          }
         },
 
         adjustPosition: function()


### PR DESCRIPTION
when the instance is not bound to a field, the function 'draw' will occur an error. Cause 'this._o.field' is null and 'this._o.field.setAttribute' is not an available function . I add a 'if-else' replace it and implement the original purpose. Please merge.
