### PR TITLE
Fix position when trigger is an SVG element

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -990,7 +990,7 @@
 
         adjustPosition: function()
         {
-            var field, pEl, width, height, viewportWidth, viewportHeight, scrollTop, left, top, clientRect;
+            var field, pEl, fieldWidth, fieldHeight, width, height, viewportWidth, viewportHeight, scrollTop, left, top, clientRect;
 
             if (this._o.container) return;
 
@@ -998,6 +998,8 @@
 
             field = this._o.trigger;
             pEl = field;
+            fieldWidth = (typeof field.getBBox === 'function') ? field.getBBox().width : field.offsetWidth
+            fieldHeight = (typeof field.getBBox === 'function') ? field.getBBox().height : field.offsetHeight
             width = this.el.offsetWidth;
             height = this.el.offsetHeight;
             viewportWidth = window.innerWidth || document.documentElement.clientWidth;
@@ -1021,18 +1023,18 @@
             if ((this._o.reposition && left + width > viewportWidth) ||
                 (
                     this._o.position.indexOf('right') > -1 &&
-                    left - width + field.offsetWidth > 0
+                    left - width + fieldWidth > 0
                 )
             ) {
-                left = left - width + field.offsetWidth;
+                left = left - width + fieldWidth;
             }
             if ((this._o.reposition && top + height > viewportHeight + scrollTop) ||
                 (
                     this._o.position.indexOf('top') > -1 &&
-                    top - height - field.offsetHeight > 0
+                    top - height - field.fieldHeight > 0
                 )
             ) {
-                top = top - height - field.offsetHeight;
+                top = top - height - fieldHeight;
             }
 
             this.el.style.left = left + 'px';


### PR DESCRIPTION
I'm using Pickaday in combination with Highcharts/Highstock, and requires the trigger to be an SVG element. Positioning isn't playing ball as SVG elements don't have offsetWidth or offsetHeight. This change tests for the getBBox function on the element, and will use that if available, falling back to offsetWidth/offsetHeight.