### PR TITLE
jQuery plugin: rename relative path to pikaday to npm package name

### DIFF
--- a/plugins/pikaday.jquery.js
+++ b/plugins/pikaday.jquery.js
@@ -10,7 +10,7 @@
 
     if (typeof exports === 'object') {
         // CommonJS module
-        factory(require('jquery'), require('../pikaday'));
+        factory(require('jquery'), require('pikaday'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['jquery', 'pikaday'], factory);


### PR DESCRIPTION
In the jQuery plugin there's a `require('../pikaday')` which was causing havoc when I was using browserify and browserify-shim. Removing the `../` seemed to do the trick. Looks unnecessary to have it there in the first place too.