### PR TITLE
Added selectDayFn for multiple date selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Pikaday has many useful options:
 * `maxDate` the maximum/latest date that can be selected (this should be a native Date object - e.g. `new Date()` or `moment().toDate()`)
 * `disableWeekends` disallow selection of Saturdays or Sundays
 * `disableDayFn` callback function that gets passed a Date object for each day in view. Should return true to disable selection of that day.
+* `selectDayFn` callback function that gets passed a Date object for each day in view. Should return true to select that day.
 * `yearRange` number of years either side (e.g. `10`) or array of upper/lower range (e.g. `[1900,2015]`)
 * `showWeekNumber` show the ISO week number at the head of the row (default `false`)
 * `isRTL` reverse the calendar for right-to-left languages

--- a/pikaday.js
+++ b/pikaday.js
@@ -664,6 +664,8 @@
 
             opts.disableDayFn = (typeof opts.disableDayFn) === 'function' ? opts.disableDayFn : null;
 
+            opts.selectDayFn = (typeof opts.selectDayFn) === 'function' ? opts.selectDayFn : null;
+
             var nom = parseInt(opts.numberOfMonths, 10) || 1;
             opts.numberOfMonths = nom > 4 ? 4 : nom;
 
@@ -981,7 +983,7 @@
             if (typeof this._o.onDraw === 'function') {
                 this._o.onDraw(this);
             }
-            
+
             if (opts.bound) {
                 // let the screen reader user know to use arrow keys
                 opts.field.setAttribute('aria-label', 'Use the arrow keys to pick a date');
@@ -1071,7 +1073,8 @@
             for (var i = 0, r = 0; i < cells; i++)
             {
                 var day = new Date(year, month, 1 + (i - before)),
-                    isSelected = isDate(this._d) ? compareDates(day, this._d) : false,
+                    isSelected = (opts.selectDayFn && opts.selectDayFn(day)) ||
+                                 (isDate(this._d) && compareDates(day, this._d)),
                     isToday = compareDates(day, now),
                     isEmpty = i < before || i >= (days + before),
                     dayNumber = 1 + (i - before),


### PR DESCRIPTION
I've added a very simple solution for selecting multiple dates using Pikaday. It uses a callback function like disableDayFn to select multiple days:

```javascript
        const options = {
            firstDay: 1,
            onSelect: (date) => {
                // Format selected date
                const formattedDate = Moment(date).format('YYYY-MM-DD');

                // Remove date if it was previous selected
                if (this.selectedDates.includes(formattedDate)) {
                    this.selectedDates = this.selectedDates.filter((date) => date !== formattedDate);
                }

                // Otherwise add it to the selected dates
                else {
                    this.selectedDates.push(formattedDate);
                }                
            },
            selectDayFn: (date) => {
                // Check if a day is selected
                const formattedDate = Moment(date).format('YYYY-MM-DD');
                return this.selectedDates.includes(formattedDate);
            },
        };

        this.datePicker = new Pikaday(options);
```