### PR TITLE
Fixed issue #611: Pressing enter or escape when no field is bound will cause an error.

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -486,7 +486,9 @@
                 switch(e.keyCode){
                     case 13:
                     case 27:
-                        opts.field.blur();
+                        if (opts.field) {
+                            opts.field.blur();
+                        }
                         break;
                     case 37:
                         e.preventDefault();


### PR DESCRIPTION
Fixed issue #611: Pressing enter or escape when no field is bound will cause an error.

After upgrading to latest Pikaday release, lots of exceptions are logged in our application due to this issue.
We had to revert to previous version of Pikaday. 

I have just added a null check that solves this problem.