### PR TITLE
Configure if field is blurred when date is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Pikaday has many useful options:
 * `numberOfMonths` number of visible calendars
 * `mainCalendar` when `numberOfMonths` is used, this will help you to choose where the main calendar will be (default `left`, can be set to `right`). Only used for the first display or when a selected date is not already visible
 * `theme` define a classname that can be used as a hook for styling different themes, see [theme example][] (default `null`)
+* `blurFieldOnSelect` defines if the field is blurred when a date is selected (default `true`)
 * `onSelect` callback function for when a date is selected
 * `onOpen` callback function for when the picker becomes visible
 * `onClose` callback function for when the picker is hidden

--- a/pikaday.js
+++ b/pikaday.js
@@ -246,6 +246,9 @@
         // Specify a DOM element to render the calendar in
         container: undefined,
 
+        // Blur field when date is selected
+        blurFieldOnSelect : true,
+
         // internationalization
         i18n: {
             previousMonth : 'Previous Month',
@@ -436,7 +439,7 @@
                     if (opts.bound) {
                         sto(function() {
                             self.hide();
-                            if (opts.field) {
+                            if (opts.blurFieldOnSelect && opts.field) {
                                 opts.field.blur();
                             }
                         }, 100);


### PR DESCRIPTION
By default Pikaday blurs the input field making tabbing across the forms input fields harder.

Added setting `blurFieldOnSelect` which controls if the the field should be blurred.