### PR TITLE
Fix broken getDate API

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   },
   "devDependencies": {
     "mocha": "~1.18.2",
-    "expect.js": "^0.3.1"
+    "expect.js": "^0.3.1",
+    "testling": "^1.7",
+    "jshint": "^2.9"
   },
   "testling": {
     "harness": "mocha",
@@ -41,5 +43,9 @@
       "safari/latest",
       "opera/latest"
     ]
+  },
+  "scripts": {
+    "test": "testling",
+    "lint": "jshint *.js plugins/*.js tests/*.js"
   }
 }

--- a/pikaday.js
+++ b/pikaday.js
@@ -735,11 +735,11 @@
         },
 
         /**
-         * return a Date object of the current selection with fallback for the current date
+         * return a Date object of the current selection
          */
         getDate: function()
         {
-            return isDate(this._d) ? new Date(this._d.getTime()) : new Date();
+            return isDate(this._d) ? new Date(this._d.getTime()) : null;
         },
 
         /**
@@ -822,7 +822,7 @@
 
         adjustDate: function(sign, days) {
 
-            var day = this.getDate();
+            var day = this.getDate() || new Date();
             var difference = parseInt(days)*24*60*60*1000;
 
             var newDay;

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -5,6 +5,12 @@ describe('Pikaday public method', function ()
 {
     'use strict';
 
+    describe('#getDate()', function() {
+        it('should return null if date not set', function() {
+            expect(new Pikaday().getDate()).to.be(null);
+        });
+    });
+
     describe('#toString()', function ()
     {
         it('should return empty string when date not set', function ()


### PR DESCRIPTION
The documentation for getDate states it should return "null if no selection". This behaviour was
however changed in https://github.com/dbushell/Pikaday/commit/3f4b9c939016125904f4d1b053e81db064bf02d8#diff-5e6a2e8d597bd0e8a3111ba17c4a0815L699 when enabling keyboard navigation, breaking the API. Revert the change of getDate and modify the keybaord navigation to default to the current time.

As I have not found any documentation on testing, this pull request contains a second commit to make (local) testing and linting available via NPM, in the hope that this will be helpful to new contributors (like me :) ).