### PR TITLE
Add an optional formatter function option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ var picker = new Pikaday({
 field.parentNode.insertBefore(picker.el, field.nextSibling);
 ```
 
-For advanced formatting load [Moment.js][moment] prior to Pikaday:
+### Formatting
+
+By default, dates are formatted and parsed using standard javascript Date object.
+If [Moment.js][moment] is available in scope, it will be used to format and parse input values. You can pass an additional `format` option to the configuration which will be passed to the `moment` constructor.
 See the [moment.js example][] for a full version.
 
 ```html
@@ -77,6 +80,40 @@ See the [moment.js example][] for a full version.
 </script>
 ```
 
+For more advanced and flexible formatting you can pass your own `toString` function to the configuration which will be used to format the date object.
+This function has the following signature:
+
+`toString(date, format = 'YYYY-MM-DD')`
+
+You should return a string from it.
+
+Be careful, though. If the formatted string that you return cannot be correctly parsed by the `Date.parse` method (or by `moment` if it is available), then you must provide your own `parse` function in the config. This function will be passed the formatted string and the format:
+
+`toString(dateString, format = 'YYYY-MM-DD')`
+
+```javascript
+var picker = new Pikaday({
+    field: document.getElementById('datepicker'),
+    format: 'D/M/YYYY',
+    toString(date, format) {
+        // you should do formatting based on the passed format,
+        // but we will just return 'D/M/YYYY' for simplicity
+        const day = date.getDate();
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+        return `${day}/${month}/${year}`;
+    },
+    parse(dateString, format) {
+        // dateString is the result of `toString` method
+        const parts = dateString.split('/');
+        const day = parseInt(parts[0], 10); 
+        const month = parseInt(parts[1] - 1, 10); 
+        const year = parseInt(parts[1], 10); 
+        return new Date(year, month, day);
+    }
+});
+```
+
 ### Configuration
 
 As the examples demonstrate above
@@ -90,6 +127,8 @@ Pikaday has many useful options:
 * `container` DOM node to render calendar into, see [container example][] (default: undefined)
 * `format` the default output format for `.toString()` and `field` value (requires [Moment.js][moment] for custom formatting)
 * `formatStrict` the default flag for moment's strict date parsing (requires [Moment.js][moment] for custom formatting)
+* `toString(date, format)` function which will be used for custom formatting. This function will take precedence over `moment`.
+* `parse(dateString, format)` function which will be used for parsing input string and getting a date object from it. This function will take precedence over `moment`.
 * `defaultDate` the initial date to view when first opened
 * `setDefaultDate` make the `defaultDate` the initial selected value
 * `firstDay` first day of the week (0: Sunday, 1: Monday, etc)
@@ -182,7 +221,10 @@ var picker = new Pikaday({ field: document.getElementById('datepicker') });
 
 `picker.toString('YYYY-MM-DD')`
 
-Returns the selected date in a string format. If [Moment.js][moment] exists (recommended) then Pikaday can return any format that Moment understands, otherwise you're stuck with JavaScript's default.
+Returns the selected date in a string format. If [Moment.js][moment] exists (recommended) then Pikaday can return any format that Moment understands.
+You can also provide your own `toString` function and do the formatting yourself. Read more in the [formatting](#formatting) section.
+
+If neither `moment` object exists nor `toString` function is provided, JavaScript's default [`.toDateString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString) method will be used.
 
 `picker.getDate()`
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -193,9 +193,12 @@
         // the default output format for `.toString()` and `field` value
         format: 'YYYY-MM-DD',
 
-        // the formatter function which gets passed a current date object and format
+        // the toString function which gets passed a current date object and format
         // and returns a string
-        formatter: null,
+        toString: null,
+
+        // used to create date object from current input string
+        parse: null,
 
         // the initial date to view when first opened
         defaultDate: null,
@@ -527,7 +530,9 @@
             if (e.firedBy === self) {
                 return;
             }
-            if (hasMoment) {
+            if (opts.parse) {
+                date = opts.parse(opts.field.value, opts.format);
+            } else if (hasMoment) {
                 date = moment(opts.field.value, opts.format, opts.formatStrict);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }
@@ -718,11 +723,11 @@
         toString: function(format)
         {
             format = format || this._o.format;
-            if (!isDate) {
+            if (!isDate(this._d)) {
                 return '';
             }
-            if (this._o.formatter) {
-              return this._o.formatter(this._d, format);
+            if (this._o.toString) {
+              return this._o.toString(this._d, format);
             }
             if (hasMoment) {
               return moment(this._d).format(format);

--- a/pikaday.js
+++ b/pikaday.js
@@ -193,6 +193,10 @@
         // the default output format for `.toString()` and `field` value
         format: 'YYYY-MM-DD',
 
+        // the formatter function which gets passed a current date object and format
+        // and returns a string
+        formatter: null,
+
         // the initial date to view when first opened
         defaultDate: null,
 
@@ -713,7 +717,17 @@
          */
         toString: function(format)
         {
-            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
+            format = format || this._o.format;
+            if (!isDate) {
+                return '';
+            }
+            if (this._o.formatter) {
+              return this._o.formatter(this._d, format);
+            }
+            if (hasMoment) {
+              return moment(this._d).format(format);
+            }
+            return this._d.toDateString();
         },
 
         /**

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -28,6 +28,38 @@ describe('Pikaday public method', function ()
             pikaday.setDate(date);
             expect(pikaday.toString()).to.eql('25-04-14');
         });
+
+        it('should use formatter function if one is provided', function () {
+            var date = new Date(2014, 3, 25),
+            pikaday = new Pikaday({
+                formatter: function(d) {
+                    var date = d.getDate();
+                    var month = d.getMonth() + 1;
+                    return 'custom: ' + date + '/' + month;
+                }
+            });
+
+            pikaday.setDate(date);
+            expect(pikaday.toString()).to.eql('custom: 25/4');
+        });
+
+        it('should pass current format option to the formatter function', function () {
+            var date = new Date(2014, 3, 25);
+            var expectedFormat = 'DD/MM/YYYY';
+            var passedFormat;
+
+            var pikaday = new Pikaday({
+                format: expectedFormat,
+                formatter: function(d, format) {
+                    passedFormat = format;
+                    return '';
+                }
+            });
+
+            pikaday.setDate(date);
+            pikaday.toString(); // invoke toString to set the passedFormat variable
+            expect(passedFormat).to.eql(expectedFormat);
+        });
     });
 
     describe('When specifying minDate option in Constructor', function () {

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -29,10 +29,10 @@ describe('Pikaday public method', function ()
             expect(pikaday.toString()).to.eql('25-04-14');
         });
 
-        it('should use formatter function if one is provided', function () {
+        it('should use toString function if one is provided', function () {
             var date = new Date(2014, 3, 25),
             pikaday = new Pikaday({
-                formatter: function(d) {
+                toString: function(d) {
                     var date = d.getDate();
                     var month = d.getMonth() + 1;
                     return 'custom: ' + date + '/' + month;
@@ -43,14 +43,14 @@ describe('Pikaday public method', function ()
             expect(pikaday.toString()).to.eql('custom: 25/4');
         });
 
-        it('should pass current format option to the formatter function', function () {
+        it('should pass current format option to the toString function', function () {
             var date = new Date(2014, 3, 25);
             var expectedFormat = 'DD/MM/YYYY';
             var passedFormat;
 
             var pikaday = new Pikaday({
                 format: expectedFormat,
-                formatter: function(d, format) {
+                toString: function(d, format) {
                     passedFormat = format;
                     return '';
                 }
@@ -58,6 +58,53 @@ describe('Pikaday public method', function ()
 
             pikaday.setDate(date);
             pikaday.toString(); // invoke toString to set the passedFormat variable
+            expect(passedFormat).to.eql(expectedFormat);
+        });
+
+        it('should use parse function if one is provided', function () {
+            var date = new Date(2014, 3, 25);
+            var expectedDate = new Date(2017, 3, 6);
+            var pikaday = new Pikaday({
+                parse: function(value, format) {
+                    return new Date(2017, 3, 6);
+                }
+            });
+
+            // mock input field
+            pikaday._o.field = {
+                value: '',
+                setAttribute: function() {},
+                dispatchEvent: function() {},
+            };
+            pikaday._onInputChange({});
+
+            expect(pikaday.getDate().getTime()).to.eql(expectedDate.getTime());
+        });
+
+        it('should pass input value and current format to the parse function', function () {
+            var date = new Date(2014, 3, 25);
+            var expectedValue = 'test value';
+            var expectedFormat = 'DD/MM/YYYY';
+            var passedValue;
+            var passedFormat;
+            var pikaday = new Pikaday({
+                format: expectedFormat,
+                parse: function(value, format) {
+                    passedValue = value;
+                    passedFormat = format;
+                    return new Date(2017, 3, 6);
+                }
+            });
+
+            // mock input field
+            pikaday._o.field = {
+                value: expectedValue,
+                setAttribute: function() {},
+                dispatchEvent: function() {},
+            };
+            pikaday._onInputChange({});
+
+            expect(passedValue).to.eql(expectedValue);
             expect(passedFormat).to.eql(expectedFormat);
         });
     });


### PR DESCRIPTION
This is a pull request for https://github.com/dbushell/Pikaday/issues/653

I decided to give a "formatter" function a higher proriority than formatting with moment: if someone uses this option he might still wish to do custom formatting even if moment is available (and may be even with its help).

Again, this is the logic (it pretty much preserves the current flow):

* if current date is not a valid object, return `''`
* if custom formatter is provided, use it and pass current date object to it and a current `format` string
* if not, use `moment` to format date according to `format` string
* else use .toDateString()

If the `formatter` option is not provided the library behaves the same as before.