### PR TITLE
Add customization functions for date formatting: parse and toString

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -271,7 +271,11 @@
         onSelect: null,
         onOpen: null,
         onClose: null,
-        onDraw: null
+        onDraw: null,
+
+        // customization functions 
+        parse: null,
+        toString: null,
     },
 
 
@@ -526,7 +530,9 @@
             if (e.firedBy === self) {
                 return;
             }
-            if (hasMoment) {
+            if ( typeof opts.parse === 'function' ) {
+                date = opts.parse(opts.field.value, opts.format, opts.formatStrict);
+            } else if (hasMoment) {
                 date = moment(opts.field.value, opts.format, opts.formatStrict);
                 date = (date && date.isValid()) ? date.toDate() : null;
             }
@@ -614,7 +620,9 @@
             addEvent(opts.field, 'change', self._onInputChange);
 
             if (!opts.defaultDate) {
-                if (hasMoment && opts.field.value) {
+                if ( typeof opts.parse === 'function' ) {
+                    opts.defaultDate = opts.parse(opts.field.value, opts.format);
+                } else if (hasMoment && opts.field.value) {
                     opts.defaultDate = moment(opts.field.value, opts.format).toDate();
                 } else {
                     opts.defaultDate = new Date(Date.parse(opts.field.value));
@@ -716,7 +724,17 @@
          */
         toString: function(format)
         {
-            return !isDate(this._d) ? '' : hasMoment ? moment(this._d).format(format || this._o.format) : this._d.toDateString();
+            if (!isDate(this._d)) {
+                return '';
+            }
+
+            if ( typeof this._o.toString === 'function' ) {
+                return this._o.toString(this._d, format || this._o.format);
+            } else if (hasMoment) {
+                return moment(this._d).format(format || this._o.format);
+            } else {
+                return this._d.toDateString();
+            }
         },
 
         /**


### PR DESCRIPTION
This patch is an alternative to #660 with less code and more functionality.
Makes Pikaday usable without Moment behemoth.

Adds 2 new options with (hopefully) obvious names:

1. **parse** - user defined function, used by Pikaday for parsing date strings. Usage:
function(date_string, format = '', format_strict = false)
should parse date_string and return Date object. format and format_strict are optional and used same way as in moment library
2. **toString** - user defined function, used by Pikaday for date output. Usage:
function(date, format = '')
should return string representation of date using optional format setting

### Typical usage example
```javascript
<!-- Change date output format to "dd.mm.yyyy" -->

<link rel="stylesheet" href="pikaday.css">
<input type="text" id="datepicker" value="30.01.2011">

<script src="pikaday.js"></script>
<script>
var picker = new Pikaday({
	field: document.getElementById('datepicker'),

	parse: function(date_string, format = '', format_strict = false) {
		var matches = null;
		// parse "dd?mm?yyyy" dates
		var regex = new RegExp("^([0-9]{1,2})[^0-9]([0-9]{1,2})[^0-9]([0-9]{4})$", "i");
		matches = regex.exec(date_string);
		if (matches != null) {
			var regex = new RegExp(matches[0], "i");
			return new Date(Date.parse(date_string.replace(regex, matches[3] + "/" + matches[2] + "/" + matches[1])));
		}
		return new Date(Date.parse(date_string)); // fallback to default parse
	},
 
	toString: function(date, format = '') {
		const year = date.getFullYear()
			,month = date.getMonth() + 1
			,day = date.getDate();
		return [
			day < 10 ? '0' + day : day,
			month < 10 ? '0' + month : month,
			year
		].join('.');	
	},
});
</script>

```
