### PR TITLE
Add canOpen callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Pikaday has many useful options:
 * `blurFieldOnSelect` defines if the field is blurred when a date is selected (default `true`)
 * `onSelect` callback function for when a date is selected
 * `onOpen` callback function for when the picker becomes visible
+* `canOpen` callback function for asking if the picker should open
 * `onClose` callback function for when the picker is hidden
 * `onDraw` callback function for when the picker draws a new month
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -270,6 +270,7 @@
         // callback function
         onSelect: null,
         onOpen: null,
+        canOpen: null,
         onClose: null,
         onDraw: null
     },
@@ -1154,7 +1155,11 @@
 
         show: function()
         {
-            if (!this.isVisible()) {
+            var canOpen = true;
+            if(typeof this._o.canOpen === 'function') {
+                canOpen = this._o.canOpen.call(this);
+            }
+            if (canOpen && !this.isVisible()) {
                 this._v = true;
                 this.draw();
                 if (this._o.bound) {


### PR DESCRIPTION
Added an optional canOpen callback to the configuration. Before a picker
is opened it will check if the callback is defined and only opens the
picker when it returns true.