### PR TITLE
mousedown to mouseup

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -452,7 +452,7 @@
         var self = this,
             opts = self.config(options);
 
-        self._onMouseDown = function(e)
+        self._onMouseUp = function(e)
         {
             if (!self._v) {
                 return;
@@ -621,12 +621,12 @@
         self.el = document.createElement('div');
         self.el.className = 'pika-single' + (opts.isRTL ? ' is-rtl' : '') + (opts.theme ? ' ' + opts.theme : '');
 
-        addEvent(self.el, 'mousedown', self._onMouseDown, true);
-        addEvent(self.el, 'touchend', self._onMouseDown, true);
+        addEvent(self.el, 'mouseup', self._onMouseUp, true);
+        addEvent(self.el, 'touchend', self._onMouseUp, true);
         addEvent(self.el, 'change', self._onChange);
 
         if (opts.keyboardInput) {
-            addEvent(document, 'keydown', self._onKeyChange);
+            addEvent(document, 'keyup', self._onKeyChange);
         }
 
         if (opts.field) {
@@ -1223,11 +1223,11 @@
             var opts = this._o;
 
             this.hide();
-            removeEvent(this.el, 'mousedown', this._onMouseDown, true);
-            removeEvent(this.el, 'touchend', this._onMouseDown, true);
+            removeEvent(this.el, 'mouseup', this._onMouseUp, true);
+            removeEvent(this.el, 'touchend', this._onMouseUp, true);
             removeEvent(this.el, 'change', this._onChange);
             if (opts.keyboardInput) {
-                removeEvent(document, 'keydown', this._onKeyChange);
+                removeEvent(document, 'keyup', this._onKeyChange);
             }
             if (opts.field) {
                 removeEvent(opts.field, 'change', this._onInputChange);


### PR DESCRIPTION
Anecdotally speaking, I find myself holding clicks quite often, especially if I'm having trouble deciding on something, such as a date.  I think mousedown is rather strange UX, most of the major airline / travel sites seem to agree with me.

The only downside to this switch I can see, is that using keyboard input, users would be unable to hold down the button to 'scroll' through dates.  I'm willing to concede keypresses, as keyboard input is disabled in my app.

Some illustrations of the differences of keyup vs keydown (among others):
[jsbin - keypress v keydown v keyup](http://jsbin.com/wunewafiwe/edit?html,css,js,console,output)
[stackoverflow - an explanation of the different keypresses we just witnessed above](https://stackoverflow.com/questions/3396754/onkeypress-vs-onkeyup-and-onkeydown)

