### PR TITLE
Fixes #709 - keyboard selection issue because of BST

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -862,14 +862,12 @@
         adjustDate: function(sign, days) {
 
             var day = this.getDate() || new Date();
-            var difference = parseInt(days)*24*60*60*1000;
-
-            var newDay;
+            var newDay = new Date(day);
 
             if (sign === 'add') {
-                newDay = new Date(day.valueOf() + difference);
+                newDay.setDate(newDay.getDate() + days);
             } else if (sign === 'subtract') {
-                newDay = new Date(day.valueOf() - difference);
+                newDay.setDate(newDay.getDate() + -Math.abs(days));
             }
 
             this.setDate(newDay);


### PR DESCRIPTION
Currently you cannot select a date beyond october 29th, because of a BST issue.  (BST-change is on that date)

The code currently doesn't consider the BST change, which is why `adjustDate: function("add", 1)` will not work. This PR fixes this.
