### PR TITLE
Remove the Moment.js optional dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "type": "git",
     "url": "https://github.com/dbushell/Pikaday.git"
   },
-  "optionalDependencies": {
-    "moment": "2.x"
-  },
   "devDependencies": {
     "mocha": "~1.18.2",
     "expect.js": "^0.3.1",


### PR DESCRIPTION
As discussed in #718

Otherwise npm will try to install Moment.js (even if it is optional) and because of this, Webpack automatically includes Moment.js in the bundle (Pikaday uses require('moment').
Users who still want to use Moment.js with Pikaday, can manually add it to their package.json file and everything will work as expected.

This change has the benefit that people who use bundle software don't need to change their config to ignore Moment.js and people who do want it usually add it to their package.json anyway.

I don't think I need to make changes to the readme. People who want to use Moment.js can take a look at the moment.js docs for installation instructions.