### PR TITLE
Prevent TypeError when using Pikaday in Firefox add-ons

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -46,7 +46,7 @@
         } else {
             return window.setTimeout;
         }
-    },
+    }(),
 
     addEvent = function(el, e, callback, capture)
     {

--- a/pikaday.js
+++ b/pikaday.js
@@ -39,7 +39,7 @@
 
     document = window.document,
 
-    sto = window.setTimeout,
+    sto = window.setTimeout.bind(window),
 
     addEvent = function(el, e, callback, capture)
     {

--- a/pikaday.js
+++ b/pikaday.js
@@ -39,7 +39,14 @@
 
     document = window.document,
 
-    sto = window.setTimeout.bind(window),
+    sto = function()
+    {
+        if (Function.prototype.bind) {
+            return window.setTimeout.bind(window);
+        } else {
+            return window.setTimeout;
+        }
+    },
 
     addEvent = function(el, e, callback, capture)
     {


### PR DESCRIPTION
```
TypeError: 'setTimeout' called on an object that does not implement interface Window.
Stack trace:
draw@moz-extension://3a5e5281-7f0c-437e-afde-3d0a4ecf512d/lib/pikaday/pikaday.js:983:21
adjustCalendars@moz-extension://3a5e5281-7f0c-437e-afde-3d0a4ecf512d/lib/pikaday/pikaday.js:852:13
gotoDate@moz-extension://3a5e5281-7f0c-437e-afde-3d0a4ecf512d/lib/pikaday/pikaday.js:817:13
setDate@moz-extension://3a5e5281-7f0c-437e-afde-3d0a4ecf512d/lib/pikaday/pikaday.js:772:13
Pikaday/self._onMouseDown@moz-extension://3a5e5281-7f0c-437e-afde-3d0a4ecf512d/lib/pikaday/pikaday.js:435:21
```

I had this issue after [porting a Chrome extension to Firefox](https://github.com/sonicmax/ChromeLL-2.0-for-Firefox/issues/4). The datepicker fails to open as the sto() call in Pikaday.draw() throws an exception and stops execution.

I'm not sure exactly what the difference in behaviour is caused by (possibly some kind of security feature?) but binding the window object to setTimeout prevents the errors and doesn't seem to affect functionality in any browsers I tested. Testing for Function.prototype.bind makes sure that the fix doesn't break compatibility for older browsers.