### PR TITLE
Create a date only when the field has a value

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -642,7 +642,7 @@
             if (!opts.defaultDate) {
                 if (hasMoment && opts.field.value) {
                     opts.defaultDate = moment(opts.field.value, opts.format).toDate();
-                } else {
+                } else if(opts.field.value) {
                     opts.defaultDate = new Date(Date.parse(opts.field.value));
                 }
                 opts.setDefaultDate = true;


### PR DESCRIPTION
A date should only being created when a field has a value. This code normaly works out of the box. But there are JS libraries around which do overload the parse function (please don't ask which one I'm fighting with) and then a date pointing to 1.1.1970 is created instead of an invalid date.