### PR TITLE
feature: add on paginate callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Pikaday has many useful options:
 * `onOpen` callback function for when the picker becomes visible
 * `onClose` callback function for when the picker is hidden
 * `onDraw` callback function for when the picker draws a new month
+* `onPaginate` callback function for the `prevMonth` and `nextMonth` methods, also fired when the pagination clicked.  
 * `keyboardInput` enable keyboard input support (default `true`)
 
 ### Styling

--- a/pikaday.js
+++ b/pikaday.js
@@ -737,7 +737,7 @@
 
             opts.disableDayFn = (typeof opts.disableDayFn) === 'function' ? opts.disableDayFn : null;
 
-            opts.onPaginate = (typeof opts.onPaginate) === 'function' ? opts.onPaginate : null
+            opts.onPaginate = (typeof opts.onPaginate) === 'function' ? opts.onPaginate : null;
 
             var nom = parseInt(opts.numberOfMonths, 10) || 1;
             opts.numberOfMonths = nom > 4 ? 4 : nom;
@@ -951,7 +951,7 @@
             this.adjustCalendars();
 
             if (typeof this._o.onPaginate === 'function') {
-                this._o.onPaginate('next', this.calendars[0].month)
+                this._o.onPaginate('next', this.calendars[0].month);
             }
         },
 
@@ -961,7 +961,7 @@
             this.adjustCalendars();
 
             if (typeof this._o.onPaginate === 'function') {
-                this._o.onPaginate('prev', this.calendars[0].month)
+                this._o.onPaginate('prev', this.calendars[0].month);
             }
         },
 

--- a/pikaday.js
+++ b/pikaday.js
@@ -285,6 +285,7 @@
         onOpen: null,
         onClose: null,
         onDraw: null,
+        onPaginate: null,
 
         // Enable keyboard input
         keyboardInput: true
@@ -736,6 +737,8 @@
 
             opts.disableDayFn = (typeof opts.disableDayFn) === 'function' ? opts.disableDayFn : null;
 
+            opts.onPaginate = (typeof opts.onPaginate) === 'function' ? opts.onPaginate : null
+
             var nom = parseInt(opts.numberOfMonths, 10) || 1;
             opts.numberOfMonths = nom > 4 ? 4 : nom;
 
@@ -946,12 +949,20 @@
         {
             this.calendars[0].month++;
             this.adjustCalendars();
+
+            if (typeof this._o.onPaginate === 'function') {
+                this._o.onPaginate('next', this.calendars[0].month)
+            }
         },
 
         prevMonth: function()
         {
             this.calendars[0].month--;
             this.adjustCalendars();
+
+            if (typeof this._o.onPaginate === 'function') {
+                this._o.onPaginate('prev', this.calendars[0].month)
+            }
         },
 
         /**

--- a/pikaday.js
+++ b/pikaday.js
@@ -951,7 +951,7 @@
             this.adjustCalendars();
 
             if (typeof this._o.onPaginate === 'function') {
-                this._o.onPaginate('next', this.calendars[0].month);
+                this._o.onPaginate('next', this.calendars[0].month, this.calendars[0].year);
             }
         },
 
@@ -961,7 +961,7 @@
             this.adjustCalendars();
 
             if (typeof this._o.onPaginate === 'function') {
-                this._o.onPaginate('prev', this.calendars[0].month);
+                this._o.onPaginate('prev', this.calendars[0].month, this.calendars[0].year);
             }
         },
 


### PR DESCRIPTION
In our system, we would like to fetch new data (enabled/disabled days mostly) when the user using the Pikadays' paginator. But unfortunately, you don't have a callback for this, so we had to call manually all the time the `prev/nextMonth` methods which are hard to maintain and manage on every new implementation. 

In this PR, I would like to contribute to Pikaday with these two callback functions. Both of them provides the direction and the month number in the callback.