### PR TITLE
Don't open datepicker on input change

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -595,9 +595,6 @@
             if (isDate(date)) {
               self.setDate(date);
             }
-            if (!self._v) {
-                self.show();
-            }
         };
 
         self._onInputFocus = function()


### PR DESCRIPTION
When user changes the date value by using the input, the datepicker should not open, since the date is already set.