### PR TITLE
Fix for the Screen reader accessibility in the date select of the calendar

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -408,11 +408,12 @@
 
     renderTitle = function(instance, c, year, month, refYear, randId)
     {
+        var currentDate = instance.toString('L');        
         var i, j, arr,
             opts = instance._o,
             isMinYear = year === opts.minYear,
             isMaxYear = year === opts.maxYear,
-            html = '<div id="' + randId + '" class="pika-title" role="heading" aria-live="polite">',
+            html = '<div id="' + randId + '" aria-label="' + currentDate + '" class="pika-title" role="heading" aria-live="polite">',
             monthHtml,
             yearHtml,
             prev = true,


### PR DESCRIPTION
Issue:
While the screen reader is activated, when trying to select a date the screen reader would say out ‘month month year year’ for example ‘April April 2022 2022’ instead of a date like XX.XX.20XX

Fix:
With the fix with this PR it should say out the currently selected date in the calendar modal. The fix is also optimised to say out the date in the date format of the system itself as well.

![Before fix](https://user-images.githubusercontent.com/96583692/162963621-7de4ee0c-6f8f-4360-b4e9-5fc92eb1093f.png)
![After fix](https://user-images.githubusercontent.com/96583692/162963689-57d9d7c8-fb8b-4423-80a8-ebb6337cbc67.png)
