### PR TITLE
Allow specifying aria-level in pikaday options

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Pikaday has many useful options:
 * `trigger` use a different element to trigger opening the datepicker, see [trigger example][] (default to `field`)
 * `bound` automatically show/hide the datepicker on `field` focus (default `true` if `field` is set)
 * `ariaLabel` data-attribute on the input field with an aria assistance text (only applied when `bound` is set)
+* `ariaLevel` data-attribute on the title which specifies the `heading` level the title acts as (no sensible default can be guessed)
 * `position` preferred position of the datepicker relative to the form field, e.g.: `top right`, `bottom right` **Note:** automatic adjustment may occur to avoid datepicker from being displayed outside the viewport, see [positions example][] (default to 'bottom left')
 * `reposition` can be set to false to not reposition datepicker within the viewport, forcing it to take the configured `position` (default: true)
 * `container` DOM node to render calendar into, see [container example][] (default: undefined)

--- a/pikaday.js
+++ b/pikaday.js
@@ -186,6 +186,9 @@
         // data-attribute on the input field with an aria assistance text (only applied when `bound` is set)
         ariaLabel: 'Use the arrow keys to pick a date',
 
+        // data-attribute on the title which specifies the `heading` level the title acts as (no sensible default can be guessed)
+        ariaLevel: undefined,
+
         // position of the datepicker, relative to the field (default to bottom & left)
         // ('bottom' & 'left' keywords are not used, 'top' & 'right' are modifier on the bottom/left position)
         position: 'bottom left',
@@ -412,7 +415,9 @@
             opts = instance._o,
             isMinYear = year === opts.minYear,
             isMaxYear = year === opts.maxYear,
-            html = '<div id="' + randId + '" class="pika-title" role="heading" aria-live="polite">',
+            level = parseInt(opts.ariaLevel, 10),
+            ariaLevel = (level ? (' aria-level= ' + level) : ''),
+            html = '<div id="' + randId + '" class="pika-title" role="heading"' + ariaLevel + ' aria-live="polite">',
             monthHtml,
             yearHtml,
             prev = true,


### PR DESCRIPTION
This commit allows developers to specify the `aria-level` for their
embedded `Pikaday` widget's title. We make no attempts to guess the
correct level, reasoning that only the developer writing the words

    const pikaday = new Pikaday({ ... })

knows the correct `aria-level` for their application.

----

In 2016, 3f4b9c9 merged initial accessibility support which included

    role="heading"

At that time, the ARIA spec did not mark `aria-level` as required when
`role="heading"` is provided:

    Often, `heading` elements will be referenced with the
    `aria-labelledby` attribute of the section for which they serve
    as a heading.

    If headings are organized into a logical outline, the
    `aria-level` attribute is used to indicate the nesting level.

Reference:

    https://github.com/w3c/aria/blob/d28e434e/index.html#L3255

----

In 2019 the text of the ARIA spec was updated to clarify that `aria-level` is
**required** when `role="heading"` is used:

    Often, `heading` elements will be referenced with the
    `aria-labelledby` attribute of the section for which they
    serve as a heading.

    To ensure headings are organized into a logical outline,
    authors MUST use the `aria-level` attribute to indicate the
    proper nesting level.

Reference:

    https://github.com/w3c/aria/commit/ba4689ef
