### PR TITLE
Solve the problem in the production environment built by vite

### DIFF
--- a/pikaday.js
+++ b/pikaday.js
@@ -799,7 +799,8 @@
          */
         setMoment: function(date, preventOnSelect)
         {
-            if (hasMoment && moment.isMoment(date)) {
+            const isMoment = moment.isMoment || moment.default.isMoment
+            if (hasMoment && isMoment(date)) {
                 this.setDate(date.toDate(), preventOnSelect);
             }
         },


### PR DESCRIPTION
When developing with vite4, the development environment is normal and the production environment reports an error：TypeError: r.isMoment is not a function.

This error will appear when the date is switched. It does not affect the use of the function, but it will appear whenever the date is switched.

I think this is a limitation of esbuild. Since original moment.js is in iife, esbuild transform it to esm when pre-bundling, the transformed code looks like:

``` javascript
// ...
var moment_default = hooks;
export {
  moment_default as default
};
```
which will cause
``` javascript
import * as moment from 'moment'
console.log(moment.isMoment) // undefined
console.log(moment.default.isMoment) // isMoment
```